### PR TITLE
Use move semantics when flushing transitions

### DIFF
--- a/services/actor-rust/build.rs
+++ b/services/actor-rust/build.rs
@@ -1,7 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate protobuf code for engine and replay services
     tonic_build::configure()
-        .build_server(false) // We only need clients
+        .build_server(true)
         .compile(
             &[
                 "../../proto/engine/v1/engine.proto",


### PR DESCRIPTION
## Summary
- move buffered transitions into replay requests with `std::mem::take` to keep mutex scopes minimal
- enable server generation for replay protos and add a unit test that exercises flushing against a mock replay service

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dabd7a90108330bbc6234bade598c1