### PR TITLE
Add component design docs for engine, actor, and replay services

### DIFF
--- a/docs/Individual Component Design/ACTOR.md
+++ b/docs/Individual Component Design/ACTOR.md
@@ -1,0 +1,22 @@
+# Actor Service (Rust)
+
+## Overview
+The actor connects to the engine over gRPC, rolls out full episodes with a policy, and ships transition batches to the replay service. It keeps minimal shared state (RNG-backed policy, episode counter, and a transition buffer) behind mutexes so the async runtime can interleave flush timers with episode execution.【F:services/actor-rust/src/actor.rs†L1-L111】
+
+## Execution flow
+1. **Startup**: `main.rs` loads `Config` from CLI/env, validates it, initializes tracing, and builds an `Actor`. Configuration covers engine/replay endpoints, identifiers, batching, and timeouts.【F:services/actor-rust/src/main.rs†L1-L88】【F:services/actor-rust/src/config.rs†L1-L73】
+2. **Capability discovery**: `Actor::new` dials both services, calls `GetCapabilities`, and constructs a `RandomPolicy` tailored to the advertised action space.【F:services/actor-rust/src/actor.rs†L17-L74】【F:services/actor-rust/src/policy.rs†L1-L164】
+3. **Main loop**: `Actor::run` alternates between ticking a flush interval and launching new episodes until `max_episodes` is hit or `shutdown` is requested.【F:services/actor-rust/src/actor.rs†L76-L151】
+4. **Episode rollout**: For each episode the actor calls `Reset`, iterates `Step` with policy-selected actions, and appends fully annotated transitions (state/action/obs, reward, done, timestamps) to the buffer.【F:services/actor-rust/src/actor.rs†L153-L235】
+5. **Buffer management**: When the buffer reaches `batch_size` (or the flush timer fires) the actor sends a `StoreBatch` request and clears the local queue.【F:services/actor-rust/src/actor.rs†L198-L222】【F:services/actor-rust/src/actor.rs†L237-L260】
+
+## Policies
+`policy.rs` defines a trait so future inference-backed strategies can slot in. The default `RandomPolicy` inspects the engine capability payload to either sample from a discrete space, iterate multi-discrete dimensions, or draw uniform floating point vectors for continuous boxes. It reuses a `SmallRng` and per-action scratch buffers to minimize allocations.【F:services/actor-rust/src/policy.rs†L1-L164】
+
+## Resilience & observability
+- Timeouts on `Reset`/`Step` prevent hung episodes; errors are logged and the actor continues with the next attempt.【F:services/actor-rust/src/actor.rs†L110-L196】
+- Partial batches are flushed on a fixed cadence so replay receives steady traffic even if episodes are long.【F:services/actor-rust/src/actor.rs†L96-L149】
+- Structured tracing logs cover connections, capability discovery, episode milestones, and batch uploads.【F:services/actor-rust/src/actor.rs†L17-L230】
+
+## Testing hooks
+The actor module includes async unit tests that stand up an in-process replay server and verify that `flush_buffer` drains queued transitions and forwards them over gRPC.【F:services/actor-rust/src/actor.rs†L262-L370】

--- a/docs/Individual Component Design/ENGINE.md
+++ b/docs/Individual Component Design/ENGINE.md
@@ -1,46 +1,28 @@
-## 1) Mental model: Console & Cartridges
+# Engine Service (Rust)
 
-- **Console (`engine-rust` server):** Owns networking (gRPC/tonic), metrics/tracing, buffer reuse, and registry lookups. It is game-agnostic and handles individual simulation requests.
-    
-- **Cartridge (a game crate):** Implements a small `Game` trait; encodes/decodes its own `State/Action/Obs`; enforces determinism; exposes capabilities.
+## 1. Mental model: console + cartridges
+- **Console (`engine-server`)**: A tonic-based gRPC process that keeps a cache of hot `ErasedGame` instances and hands out reusable buffers so every `Reset`/`Step` call avoids reallocation. It is responsible for translating protobuf requests into the byte-oriented engine core API and for enforcing that clients call `Reset` before `Step`.【F:services/engine-rust/engine-server/src/service.rs†L18-L124】【F:services/engine-rust/engine-server/src/buffers.rs†L1-L86】
+- **Cartridges (game crates)**: Each game implements the strongly typed `Game` trait and registers itself with the global registry. The server asks the registry for a boxed `ErasedGame`, which wraps the typed implementation and performs encode/decode work on demand.【F:services/engine-rust/engine-core/src/typed.rs†L8-L125】【F:services/engine-rust/engine-core/src/registry.rs†L1-L87】【F:services/engine-rust/engine-core/src/adapter.rs†L1-L118】
 
+## 2. Crate layout and responsibilities
+- `engine-core`: Owns the typed `Game` trait, error types, and the `GameAdapter` that bridges typed games to the erased engine-facing API. It also exposes the registry helpers that the server uses at runtime.【F:services/engine-rust/engine-core/src/typed.rs†L8-L158】【F:services/engine-rust/engine-core/src/adapter.rs†L1-L118】【F:services/engine-rust/engine-core/src/registry.rs†L1-L147】
+- `engine-proto`: Generated tonic client/server bindings for `proto/engine/v1`. The server crate consumes this crate so the wire format stays versioned independently of gameplay code.
+- `engine-server`: Hosts the gRPC implementation, buffer pooling, and the cache of initialized games so multiple `Step` calls share mutable state without rebuilding cartridges.【F:services/engine-rust/engine-server/src/service.rs†L18-L216】
+- `games-*` crates (e.g. `games-tictactoe`): Implement concrete `Game` traits and call `register_game!` in their `lib.rs` to make the environment discoverable.【F:services/engine-rust/games-tictactoe/src/lib.rs†L1-L82】
 
-## 3) Rust design: typed games + erased server
+## 3. Typed games → erased server boundary
+1. Games implement `Game` with typed `State`, `Action`, and `Obs` plus encode/decode hooks that describe how to serialize those types into reusable byte buffers.【F:services/engine-rust/engine-core/src/typed.rs†L45-L125】
+2. `GameAdapter` owns a `ChaCha20Rng` and wraps any typed game behind the object-safe `ErasedGame` trait, translating between byte buffers and typed values for every `reset`/`step` call.【F:services/engine-rust/engine-core/src/adapter.rs†L20-L118】
+3. The registry stores factories that yield boxed adapters; the server looks up an `(env_id, build_id)` pair and caches the resulting `ErasedGame` so repeated requests reuse state and RNG streams.【F:services/engine-rust/engine-core/src/registry.rs†L1-L119】【F:services/engine-rust/engine-server/src/service.rs†L30-L119】
 
-Two layers:
+## 4. Hot-path execution in the server
+- **Reset flow**: The server leases state/observation buffers from the pool, calls `ErasedGame::reset(seed, hint, …)` to fill them, and returns the filled buffers to the client before releasing them back to the pool.【F:services/engine-rust/engine-server/src/service.rs†L78-L119】【F:services/engine-rust/engine-server/src/buffers.rs†L33-L86】
+- **Step flow**: Clients provide the previous state/action bytes. The server reuses buffers to hold the next state and observation, invokes the cached game, and returns reward/done flags along with the updated bytes.【F:services/engine-rust/engine-server/src/service.rs†L120-L170】
+- **Buffer pool**: A shared `BufferPool` owns separate vectors for state, observation, and action data; each is cleared and recycled on return to minimize allocations across concurrent RPCs.【F:services/engine-rust/engine-server/src/buffers.rs†L1-L86】
 
-- **Typed `Game`** (per-cartridge): ergonomic, fast, deterministic.
-    
-- **Erased `ErasedGame`** (server-facing): works only with bytes and reusable buffers; no generics across the gRPC boundary.
-    
+## 5. Game cartridge example: Tic-Tac-Toe
+`games-tictactoe` showcases the pattern: `TicTacToe::new()` implements `Game`, encodes its 11-byte state and 116-byte observation, and registers itself so the engine can serve `env_id = "tictactoe"`. This crate is built into the Docker image, so the server can satisfy requests immediately after startup.【F:services/engine-rust/games-tictactoe/src/lib.rs†L1-L82】
 
-```rust
-// engine-core/src/typed.rs
-pub trait Game: Send + Sync + 'static {
-    type State;  // POD-like
-    type Action; // small, Copy or compact
-    type Obs;    // often contiguous f32s
-
-    fn engine_id(&self) -> EngineId;
-    fn capabilities(&self) -> Capabilities;
-
-    fn reset(&mut self, rng: &mut ChaCha20Rng, hint: &[u8]) -> (Self::State, Self::Obs);
-    fn step(&mut self, s: &mut Self::State, a: Self::Action) -> (Self::Obs, f32, bool);
-
-    fn encode_state(s: &Self::State, out: &mut Vec<u8>);
-    fn decode_state(buf: &[u8]) -> Self::State;
-    fn encode_action(a: &Self::Action, out: &mut Vec<u8>);
-    fn decode_action(buf: &[u8]) -> Self::Action;
-    fn encode_obs(o: &Self::Obs, out: &mut Vec<u8>);
-}
-
-// engine-core/src/erased.rs
-pub trait ErasedGame: Send + Sync + 'static {
-    fn engine_id(&self) -> EngineId;
-    fn capabilities(&self) -> Capabilities;
-    fn reset(&mut self, seed: u64, hint: &[u8], out_state: &mut Vec<u8>, out_obs: &mut Vec<u8>);
-    fn step(&mut self, state: &[u8], action: &[u8], out_state: &mut Vec<u8>, out_obs: &mut Vec<u8>) -> (f32, bool);
-}
-```
-
-A blanket adapter converts any `Game` to `ErasedGame` by calling its encode/decode hooks, letting the server remain generic and allocation-aware.
+## 6. Testing hooks
+- `engine-core` includes unit tests around trait ergonomics and adapter conversions so new games can rely on encode/decode helpers.【F:services/engine-rust/engine-core/src/typed.rs†L160-L246】【F:services/engine-rust/engine-core/src/adapter.rs†L120-L226】
+- `engine-server` tests the tonic service end-to-end by registering mock games and asserting reset/step buffer sizes and error handling paths.【F:services/engine-rust/engine-server/src/service.rs†L172-L284】

--- a/docs/Individual Component Design/REPLAY.md
+++ b/docs/Individual Component Design/REPLAY.md
@@ -1,0 +1,17 @@
+# Replay Service (Go)
+
+## Overview
+The Go replay service exposes the `replay.v1` gRPC API and forwards each request to a pluggable storage backend. The default `MemoryBackend` keeps per-environment indices, ordered timestamps, and episode groupings so it can serve uniform or prioritized samples while enforcing a global capacity limit.【F:services/replay-go/internal/service/replay.go†L1-L211】【F:services/replay-go/internal/storage/memory.go†L1-L240】
+
+## Components
+- **gRPC surface (`internal/service`)**: Implements every protobuf method (StoreTransition, StoreBatch, Sample, GetStats, UpdatePriorities, Clear). Each handler validates inputs, converts between proto structs and storage structs, and maps backend errors onto gRPC status codes.【F:services/replay-go/internal/service/replay.go†L1-L211】
+- **Storage interface**: Defines the `Transition` schema, sampling configuration, statistics payload, and the methods that any backend must implement. This keeps the service layer agnostic to persistence details.【F:services/replay-go/internal/storage/interface.go†L1-L61】
+- **In-memory backend**: Tracks transitions in maps plus auxiliary indices (per-episode, per-env, timestamp ordering) to support eviction, sampling, stats, and priority updates. It generates IDs, fills timestamps, and evicts oldest data when `maxSize` is exceeded.【F:services/replay-go/internal/storage/memory.go†L1-L240】【F:services/replay-go/internal/storage/memory.go†L240-L384】
+
+## Request handling highlights
+- **StoreTransition / StoreBatch**: Convert proto messages into storage transitions, auto-populating IDs and timestamps if they are missing, then update the indices and enforce capacity.【F:services/replay-go/internal/service/replay.go†L17-L74】【F:services/replay-go/internal/storage/memory.go†L25-L115】
+- **Sample**: Accepts uniform or prioritized sampling with optional timestamp windows. The backend builds a candidate set, applies weighting (including alpha-scaling for priorities), and returns transitions plus importance weights.【F:services/replay-go/internal/service/replay.go†L76-L133】【F:services/replay-go/internal/storage/memory.go†L117-L240】【F:services/replay-go/internal/storage/memory.go†L320-L432】
+- **GetStats & Clear**: Provide observability and housekeeping using the backend's aggregated counters and time index. `Clear` can drop old data before a timestamp while respecting a "keep last N" guardrail.【F:services/replay-go/internal/service/replay.go†L135-L211】【F:services/replay-go/internal/storage/memory.go†L177-L320】
+
+## Testing hooks
+`memory_test.go` exercises the in-memory backend for storing, sampling, and eviction behaviour, while `integration_test.go` runs higher-level gRPC scenarios against the compiled server binary.【F:services/replay-go/internal/storage/memory_test.go†L1-L280】【F:services/replay-go/integration_test.go†L1-L205】


### PR DESCRIPTION
## Summary
- refresh the ENGINE individual-component design doc to reflect the current engine-core, registry, and server implementation
- add ACTOR design doc describing the Rust actor configuration, execution flow, and policy abstractions
- add REPLAY design doc summarizing the Go gRPC surface and in-memory backend behaviors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad7dc5a588330bedd3f550f5ce398