### PR TITLE
Add engine step info field and TicTacToe benchmarks

### DIFF
--- a/proto/engine/v1/engine.proto
+++ b/proto/engine/v1/engine.proto
@@ -70,6 +70,7 @@ message StepResponse {
     bytes obs = 2;          // New observation encoded as bytes
     float reward = 3;       // Reward received from this step
     bool done = 4;          // Whether episode has terminated
+    uint64 info = 5;        // Additional packed info bits (game-specific semantics)
 }
 
 

--- a/services/engine-rust/engine-core/src/adapter.rs
+++ b/services/engine-rust/engine-core/src/adapter.rs
@@ -1,33 +1,33 @@
 //! Adapter layer converting typed games to erased interface
-//! 
+//!
 //! This module provides the `GameAdapter` struct that automatically converts
 //! any typed `Game` implementation to the `ErasedGame` interface, handling
 //! all encoding/decoding and random number generation management.
 
-use rand_chacha::ChaCha20Rng;
 use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 
-use crate::typed::{Game, EngineId, Capabilities};
 use crate::erased::{ErasedGame, ErasedGameError};
+use crate::typed::{Capabilities, EngineId, Game};
 
 /// Adapter that converts typed games to erased interface
-/// 
+///
 /// This struct wraps any typed `Game` implementation and provides the `ErasedGame`
 /// interface by handling all encoding/decoding operations and managing the
 /// random number generator state.
-/// 
+///
 /// The adapter maintains its own RNG instance that gets re-seeded on each reset,
 /// ensuring deterministic behavior while providing the stateless interface
 /// expected by the gRPC layer.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust
 /// # use engine_core::typed::*;
 /// # use engine_core::adapter::GameAdapter;
 /// # use engine_core::erased::ErasedGame;
 /// # use rand_chacha::ChaCha20Rng;
-/// 
+///
 /// # #[derive(Default)]
 /// # struct MyGame;
 /// # impl Game for MyGame {
@@ -37,17 +37,22 @@ use crate::erased::{ErasedGame, ErasedGameError};
 /// #     fn engine_id(&self) -> EngineId { todo!() }
 /// #     fn capabilities(&self) -> Capabilities { todo!() }
 /// #     fn reset(&mut self, rng: &mut ChaCha20Rng, hint: &[u8]) -> (Self::State, Self::Obs) { todo!() }
-/// #     fn step(&mut self, state: &mut Self::State, action: Self::Action, rng: &mut ChaCha20Rng) -> (Self::Obs, f32, bool) { todo!() }
+/// #     fn step(
+/// #         &mut self,
+/// #         state: &mut Self::State,
+/// #         action: Self::Action,
+/// #         rng: &mut ChaCha20Rng,
+/// #     ) -> (Self::Obs, f32, bool, u64) { todo!() }
 /// #     fn encode_state(state: &Self::State, out: &mut Vec<u8>) -> Result<(), EncodeError> { todo!() }
 /// #     fn decode_state(buf: &[u8]) -> Result<Self::State, DecodeError> { todo!() }
 /// #     fn encode_action(action: &Self::Action, out: &mut Vec<u8>) -> Result<(), EncodeError> { todo!() }
 /// #     fn decode_action(buf: &[u8]) -> Result<Self::Action, DecodeError> { todo!() }
 /// #     fn encode_obs(obs: &Self::Obs, out: &mut Vec<u8>) -> Result<(), EncodeError> { todo!() }
 /// # }
-/// 
+///
 /// let typed_game = MyGame::default();
 /// let mut erased_game: Box<dyn ErasedGame> = Box::new(GameAdapter::new(typed_game));
-/// 
+///
 /// // Now you can use the erased interface
 /// let engine_id = erased_game.engine_id();
 /// println!("Game: {}", engine_id.env_id);
@@ -59,7 +64,7 @@ pub struct GameAdapter<T: Game> {
 
 impl<T: Game> GameAdapter<T> {
     /// Create a new adapter wrapping the given game
-    /// 
+    ///
     /// The adapter starts with a default-seeded RNG that will be re-seeded
     /// on the first reset call.
     pub fn new(game: T) -> Self {
@@ -68,17 +73,17 @@ impl<T: Game> GameAdapter<T> {
             rng: ChaCha20Rng::seed_from_u64(0), // Will be re-seeded on reset
         }
     }
-    
+
     /// Get a reference to the underlying game
     pub fn game(&self) -> &T {
         &self.game
     }
-    
+
     /// Get a mutable reference to the underlying game
     pub fn game_mut(&mut self) -> &mut T {
         &mut self.game
     }
-    
+
     /// Consume the adapter and return the underlying game
     pub fn into_inner(self) -> T {
         self.game
@@ -89,74 +94,70 @@ impl<T: Game> ErasedGame for GameAdapter<T> {
     fn engine_id(&self) -> EngineId {
         self.game.engine_id()
     }
-    
+
     fn capabilities(&self) -> Capabilities {
         self.game.capabilities()
     }
-    
+
     fn reset(
-        &mut self, 
-        seed: u64, 
-        hint: &[u8], 
-        out_state: &mut Vec<u8>, 
-        out_obs: &mut Vec<u8>
+        &mut self,
+        seed: u64,
+        hint: &[u8],
+        out_state: &mut Vec<u8>,
+        out_obs: &mut Vec<u8>,
     ) -> Result<(), ErasedGameError> {
         // Re-seed the RNG for deterministic behavior
         self.rng = ChaCha20Rng::seed_from_u64(seed);
-        
+
         // Clear output buffers
         out_state.clear();
         out_obs.clear();
-        
+
         // Call the typed reset method
         let (state, obs) = self.game.reset(&mut self.rng, hint);
-        
+
         // Encode the results
-        T::encode_state(&state, out_state)
-            .map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
-            
-        T::encode_obs(&obs, out_obs)
-            .map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
-        
+        T::encode_state(&state, out_state).map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
+
+        T::encode_obs(&obs, out_obs).map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
+
         Ok(())
     }
-    
+
     fn step(
-        &mut self, 
-        state: &[u8], 
-        action: &[u8], 
-        out_state: &mut Vec<u8>, 
-        out_obs: &mut Vec<u8>
+        &mut self,
+        state: &[u8],
+        action: &[u8],
+        out_state: &mut Vec<u8>,
+        out_obs: &mut Vec<u8>,
     ) -> Result<(f32, bool), ErasedGameError> {
         // Clear output buffers
         out_state.clear();
         out_obs.clear();
-        
+
         // Decode the inputs
-        let mut state = T::decode_state(state)
-            .map_err(|e| ErasedGameError::Decoding(e.to_string()))?;
-            
-        let action = T::decode_action(action)
-            .map_err(|e| ErasedGameError::Decoding(e.to_string()))?;
-        
+        let mut state =
+            T::decode_state(state).map_err(|e| ErasedGameError::Decoding(e.to_string()))?;
+
+        let action =
+            T::decode_action(action).map_err(|e| ErasedGameError::Decoding(e.to_string()))?;
+
         // Call the typed step method
-        let (obs, reward, done) = self.game.step(&mut state, action, &mut self.rng);
-        
+        let (obs, reward, done, info) = self.game.step(&mut state, action, &mut self.rng);
+
         // Encode the results
-        T::encode_state(&state, out_state)
-            .map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
-            
-        T::encode_obs(&obs, out_obs)
-            .map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
-        
-        Ok((reward, done))
+        T::encode_state(&state, out_state).map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
+
+        T::encode_obs(&obs, out_obs).map_err(|e| ErasedGameError::Encoding(e.to_string()))?;
+
+        Ok((reward, done, info))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::typed::{Encoding, ActionSpace, EncodeError, DecodeError};
+    use crate::typed::{ActionSpace, DecodeError, EncodeError, Encoding};
 
     // Test game implementation
     #[derive(Debug, PartialEq)]
@@ -165,7 +166,7 @@ mod tests {
         reset_count: u32,
         step_count: u32,
     }
-    
+
     impl TestGame {
         fn new(id: String) -> Self {
             Self {
@@ -175,19 +176,19 @@ mod tests {
             }
         }
     }
-    
+
     impl Game for TestGame {
         type State = u32;
         type Action = u8;
         type Obs = Vec<f32>;
-        
+
         fn engine_id(&self) -> EngineId {
             EngineId {
                 env_id: self.id.clone(),
                 build_id: "0.1.0".to_string(),
             }
         }
-        
+
         fn capabilities(&self) -> Capabilities {
             Capabilities {
                 id: self.engine_id(),
@@ -202,53 +203,66 @@ mod tests {
                 preferred_batch: 32,
             }
         }
-        
+
         fn reset(&mut self, rng: &mut ChaCha20Rng, _hint: &[u8]) -> (Self::State, Self::Obs) {
             self.reset_count += 1;
             self.step_count = 0;
-            
+
             // Use RNG to ensure it's properly seeded
             use rand::Rng;
             let random_val = rng.gen::<u32>() % 100;
-            
+
             (random_val, vec![random_val as f32])
         }
-        
-        fn step(&mut self, state: &mut Self::State, action: Self::Action, _rng: &mut ChaCha20Rng) -> (Self::Obs, f32, bool) {
+
+        fn step(
+            &mut self,
+            state: &mut Self::State,
+            action: Self::Action,
+            _rng: &mut ChaCha20Rng,
+        ) -> (Self::Obs, f32, bool, u64) {
             self.step_count += 1;
             *state += action as u32;
-            
+
             let obs = vec![*state as f32, self.step_count as f32];
             let reward = action as f32;
             let done = *state >= 20 || self.step_count >= 10;
-            
-            (obs, reward, done)
+
+            let info = ((*state as u64) << 32) | self.step_count as u64;
+
+            (obs, reward, done, info)
         }
-        
+
         fn encode_state(state: &Self::State, out: &mut Vec<u8>) -> Result<(), EncodeError> {
             out.extend_from_slice(&state.to_le_bytes());
             Ok(())
         }
-        
+
         fn decode_state(buf: &[u8]) -> Result<Self::State, DecodeError> {
             if buf.len() != 4 {
-                return Err(DecodeError::InvalidLength { expected: 4, actual: buf.len() });
+                return Err(DecodeError::InvalidLength {
+                    expected: 4,
+                    actual: buf.len(),
+                });
             }
             Ok(u32::from_le_bytes(buf.try_into().unwrap()))
         }
-        
+
         fn encode_action(action: &Self::Action, out: &mut Vec<u8>) -> Result<(), EncodeError> {
             out.push(*action);
             Ok(())
         }
-        
+
         fn decode_action(buf: &[u8]) -> Result<Self::Action, DecodeError> {
             if buf.len() != 1 {
-                return Err(DecodeError::InvalidLength { expected: 1, actual: buf.len() });
+                return Err(DecodeError::InvalidLength {
+                    expected: 1,
+                    actual: buf.len(),
+                });
             }
             Ok(buf[0])
         }
-        
+
         fn encode_obs(obs: &Self::Obs, out: &mut Vec<u8>) -> Result<(), EncodeError> {
             // Encode length first, then values
             let len = obs.len() as u32;
@@ -264,149 +278,168 @@ mod tests {
     fn test_adapter_basic_functionality() {
         let game = TestGame::new("test".to_string());
         let adapter = GameAdapter::new(game);
-        
+
         // Test engine_id passthrough
         let id = adapter.engine_id();
         assert_eq!(id.env_id, "test");
-        
+
         // Test capabilities passthrough
         let caps = adapter.capabilities();
         assert_eq!(caps.id.env_id, "test");
         assert_eq!(caps.max_horizon, 100);
     }
-    
+
     #[test]
     fn test_adapter_reset() {
         let game = TestGame::new("test".to_string());
         let mut adapter = GameAdapter::new(game);
-        
+
         let mut state_buf = Vec::new();
         let mut obs_buf = Vec::new();
-        
-        adapter.reset(42, &[], &mut state_buf, &mut obs_buf).unwrap();
-        
+
+        adapter
+            .reset(42, &[], &mut state_buf, &mut obs_buf)
+            .unwrap();
+
         // State should be encoded as 4 bytes (u32)
         assert_eq!(state_buf.len(), 4);
         let state_value = u32::from_le_bytes(state_buf.try_into().unwrap());
-        
+
         // Obs should be encoded as length + values
         assert!(obs_buf.len() >= 4); // At least length header
         let obs_len = u32::from_le_bytes(obs_buf[0..4].try_into().unwrap());
         assert_eq!(obs_len, 1); // One f32 value
         assert_eq!(obs_buf.len(), 4 + 4); // Length + one f32
-        
+
         // Verify the observation value matches the state
         let obs_value = f32::from_le_bytes(obs_buf[4..8].try_into().unwrap());
         assert_eq!(obs_value, state_value as f32);
     }
-    
+
     #[test]
     fn test_adapter_step() {
         let game = TestGame::new("test".to_string());
         let mut adapter = GameAdapter::new(game);
-        
+
         // Reset first
         let mut state_buf = Vec::new();
         let mut obs_buf = Vec::new();
-        adapter.reset(42, &[], &mut state_buf, &mut obs_buf).unwrap();
-        
+        adapter
+            .reset(42, &[], &mut state_buf, &mut obs_buf)
+            .unwrap();
+
         // Prepare action
         let action_bytes = vec![3u8];
-        
+
         // Take a step
         let mut new_state_buf = Vec::new();
         let mut new_obs_buf = Vec::new();
-        let (reward, _done) = adapter.step(&state_buf, &action_bytes, &mut new_state_buf, &mut new_obs_buf).unwrap();
-        
+        let (reward, _done, info) = adapter
+            .step(
+                &state_buf,
+                &action_bytes,
+                &mut new_state_buf,
+                &mut new_obs_buf,
+            )
+            .unwrap();
+
         // Verify reward
         assert_eq!(reward, 3.0);
-        
+        assert!(info > 0);
+
         // Decode new state
         let new_state = u32::from_le_bytes(new_state_buf.try_into().unwrap());
         let old_state = u32::from_le_bytes(state_buf.try_into().unwrap());
         assert_eq!(new_state, old_state + 3);
-        
+
         // Verify obs structure
         assert!(new_obs_buf.len() >= 4);
         let obs_len = u32::from_le_bytes(new_obs_buf[0..4].try_into().unwrap());
         assert_eq!(obs_len, 2); // Two f32 values (state and step_count)
     }
-    
+
     #[test]
     fn test_adapter_deterministic_reset() {
         let game1 = TestGame::new("test".to_string());
         let mut adapter1 = GameAdapter::new(game1);
-        
+
         let game2 = TestGame::new("test".to_string());
         let mut adapter2 = GameAdapter::new(game2);
-        
+
         // Reset with same seed
         let mut state1 = Vec::new();
         let mut obs1 = Vec::new();
         adapter1.reset(12345, &[], &mut state1, &mut obs1).unwrap();
-        
+
         let mut state2 = Vec::new();
         let mut obs2 = Vec::new();
         adapter2.reset(12345, &[], &mut state2, &mut obs2).unwrap();
-        
+
         // Results should be identical
         assert_eq!(state1, state2);
         assert_eq!(obs1, obs2);
     }
-    
+
     #[test]
     fn test_adapter_different_seeds() {
         let game1 = TestGame::new("test".to_string());
         let mut adapter1 = GameAdapter::new(game1);
-        
+
         let game2 = TestGame::new("test".to_string());
         let mut adapter2 = GameAdapter::new(game2);
-        
+
         // Reset with different seeds
         let mut state1 = Vec::new();
         let mut obs1 = Vec::new();
         adapter1.reset(12345, &[], &mut state1, &mut obs1).unwrap();
-        
+
         let mut state2 = Vec::new();
         let mut obs2 = Vec::new();
         adapter2.reset(54321, &[], &mut state2, &mut obs2).unwrap();
-        
+
         // Results should be different (with very high probability)
         // Note: There's a tiny chance they could be the same due to randomness
         assert!(state1 != state2 || obs1 != obs2);
     }
-    
+
     #[test]
     fn test_adapter_inner_access() {
         let game = TestGame::new("test".to_string());
         let mut adapter = GameAdapter::new(game);
-        
+
         // Test mutable access
         adapter.game_mut().id = "modified".to_string();
         assert_eq!(adapter.game().id, "modified");
-        
+
         // Test into_inner
         let inner_game = adapter.into_inner();
         assert_eq!(inner_game.id, "modified");
     }
-    
+
     #[test]
     fn test_adapter_invalid_action_decoding() {
         let game = TestGame::new("test".to_string());
         let mut adapter = GameAdapter::new(game);
-        
+
         // Reset first
         let mut state_buf = Vec::new();
         let mut obs_buf = Vec::new();
-        adapter.reset(42, &[], &mut state_buf, &mut obs_buf).unwrap();
-        
+        adapter
+            .reset(42, &[], &mut state_buf, &mut obs_buf)
+            .unwrap();
+
         // Try step with invalid action (wrong length)
         let invalid_action = vec![1, 2, 3]; // Should be 1 byte
         let mut new_state_buf = Vec::new();
         let mut new_obs_buf = Vec::new();
-        
-        let result = adapter.step(&state_buf, &invalid_action, &mut new_state_buf, &mut new_obs_buf);
-        
+
+        let result = adapter.step(
+            &state_buf,
+            &invalid_action,
+            &mut new_state_buf,
+            &mut new_obs_buf,
+        );
+
         assert!(result.is_err());
         match result.unwrap_err() {
             ErasedGameError::Decoding(_) => {
@@ -415,20 +448,25 @@ mod tests {
             _ => panic!("Expected Decoding error"),
         }
     }
-    
+
     #[test]
     fn test_adapter_invalid_state_decoding() {
         let game = TestGame::new("test".to_string());
         let mut adapter = GameAdapter::new(game);
-        
+
         // Try step with invalid state (wrong length)
         let invalid_state = vec![1, 2, 3]; // Should be 4 bytes for u32
         let action = vec![1u8];
         let mut new_state_buf = Vec::new();
         let mut new_obs_buf = Vec::new();
-        
-        let result = adapter.step(&invalid_state, &action, &mut new_state_buf, &mut new_obs_buf);
-        
+
+        let result = adapter.step(
+            &invalid_state,
+            &action,
+            &mut new_state_buf,
+            &mut new_obs_buf,
+        );
+
         assert!(result.is_err());
         match result.unwrap_err() {
             ErasedGameError::Decoding(_) => {

--- a/services/engine-rust/engine-core/src/erased.rs
+++ b/services/engine-rust/engine-core/src/erased.rs
@@ -1,10 +1,10 @@
 //! Erased Game interface for runtime polymorphism
-//! 
+//!
 //! This trait provides a bytes-only interface that works across gRPC boundaries
 //! without generics. All typed games are converted to this interface via the
 //! adapter layer.
 
-use crate::typed::{EngineId, Capabilities};
+use crate::typed::{Capabilities, EngineId};
 
 /// Runtime error for erased game operations
 #[derive(Debug, thiserror::Error)]
@@ -22,20 +22,20 @@ pub enum ErasedGameError {
 }
 
 /// Erased game trait that works only with bytes
-/// 
+///
 /// This trait provides a runtime interface for games without generics,
 /// making it suitable for use across gRPC boundaries and in dynamic
 /// dispatch scenarios.
-/// 
+///
 /// All data is passed as byte slices and results are written to provided
 /// output buffers to enable allocation-free hot paths.
-/// 
+///
 /// # Example Usage
-/// 
+///
 /// ```rust
 /// # use engine_core::erased::*;
 /// # use engine_core::typed::*;
-/// 
+///
 /// fn simulate_game(game: &mut dyn ErasedGame) -> Result<(), ErasedGameError> {
 ///     let caps = game.capabilities();
 ///     println!("Simulating {}", caps.id.env_id);
@@ -48,82 +48,83 @@ pub enum ErasedGameError {
 ///     
 ///     // Take a step (would need valid action bytes)
 ///     let action_bytes = vec![0]; // Placeholder
-///     let (reward, done) = game.step(&state_buf, &action_bytes, &mut state_buf, &mut obs_buf)?;
-///     
-///     println!("Reward: {}, Done: {}", reward, done);
+///     let (reward, done, info) = game.step(&state_buf, &action_bytes, &mut state_buf, &mut obs_buf)?;
+///
+///     println!("Reward: {}, Done: {}, Info: {}", reward, done, info);
 ///     Ok(())
 /// }
 /// ```
 pub trait ErasedGame: Send + Sync + 'static {
     /// Get engine identification information
     fn engine_id(&self) -> EngineId;
-    
+
     /// Get game capabilities and configuration
     fn capabilities(&self) -> Capabilities;
-    
+
     /// Reset the game to initial state
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `seed` - Random seed for deterministic reset
     /// * `hint` - Optional hint data for environment setup
     /// * `out_state` - Buffer to write encoded initial state
     /// * `out_obs` - Buffer to write encoded initial observation
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns `ErasedGameError` if reset fails or encoding fails
     fn reset(
-        &mut self, 
-        seed: u64, 
-        hint: &[u8], 
-        out_state: &mut Vec<u8>, 
-        out_obs: &mut Vec<u8>
+        &mut self,
+        seed: u64,
+        hint: &[u8],
+        out_state: &mut Vec<u8>,
+        out_obs: &mut Vec<u8>,
     ) -> Result<(), ErasedGameError>;
-    
+
     /// Perform one simulation step
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `state` - Current state encoded as bytes
     /// * `action` - Action to take encoded as bytes
     /// * `out_state` - Buffer to write encoded new state
     /// * `out_obs` - Buffer to write encoded new observation
-    /// 
+    ///
     /// # Returns
-    /// 
-    /// Returns `Ok((reward, done))` on success, where:
+    ///
+    /// Returns `Ok((reward, done, info))` on success, where:
     /// - `reward` - Reward received from this step
     /// - `done` - Whether the episode has terminated
-    /// 
+    /// - `info` - Additional packed info bits for auxiliary signals
+    ///
     /// # Errors
-    /// 
+    ///
     /// Returns `ErasedGameError` if step fails or encoding/decoding fails
     fn step(
-        &mut self, 
-        state: &[u8], 
-        action: &[u8], 
-        out_state: &mut Vec<u8>, 
-        out_obs: &mut Vec<u8>
-    ) -> Result<(f32, bool), ErasedGameError>;
+        &mut self,
+        state: &[u8],
+        action: &[u8],
+        out_state: &mut Vec<u8>,
+        out_obs: &mut Vec<u8>,
+    ) -> Result<(f32, bool, u64), ErasedGameError>;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::typed::{Encoding, ActionSpace};
+    use crate::typed::{ActionSpace, Encoding};
 
     // Mock implementation for testing
     struct MockErasedGame {
         step_count: u32,
     }
-    
+
     impl MockErasedGame {
         fn new() -> Self {
             Self { step_count: 0 }
         }
     }
-    
+
     impl ErasedGame for MockErasedGame {
         fn engine_id(&self) -> EngineId {
             EngineId {
@@ -131,7 +132,7 @@ mod tests {
                 build_id: "0.1.0".to_string(),
             }
         }
-        
+
         fn capabilities(&self) -> Capabilities {
             Capabilities {
                 id: self.engine_id(),
@@ -146,52 +147,55 @@ mod tests {
                 preferred_batch: 16,
             }
         }
-        
+
         fn reset(
-            &mut self, 
-            _seed: u64, 
-            _hint: &[u8], 
-            out_state: &mut Vec<u8>, 
-            out_obs: &mut Vec<u8>
+            &mut self,
+            _seed: u64,
+            _hint: &[u8],
+            out_state: &mut Vec<u8>,
+            out_obs: &mut Vec<u8>,
         ) -> Result<(), ErasedGameError> {
             self.step_count = 0;
-            
+
             // Encode state as u32 (step count)
             out_state.extend_from_slice(&self.step_count.to_le_bytes());
-            
+
             // Encode observation as f32
             out_obs.extend_from_slice(&(self.step_count as f32).to_le_bytes());
-            
+
             Ok(())
         }
-        
+
         fn step(
-            &mut self, 
-            state: &[u8], 
-            _action: &[u8], 
-            out_state: &mut Vec<u8>, 
-            out_obs: &mut Vec<u8>
-        ) -> Result<(f32, bool), ErasedGameError> {
+            &mut self,
+            state: &[u8],
+            _action: &[u8],
+            out_state: &mut Vec<u8>,
+            out_obs: &mut Vec<u8>,
+        ) -> Result<(f32, bool, u64), ErasedGameError> {
             // Decode current state
             if state.len() != 4 {
-                return Err(ErasedGameError::InvalidState(
-                    format!("Expected 4 bytes, got {}", state.len())
-                ));
+                return Err(ErasedGameError::InvalidState(format!(
+                    "Expected 4 bytes, got {}",
+                    state.len()
+                )));
             }
-            
+
             let current_step = u32::from_le_bytes(state.try_into().unwrap());
             let new_step = current_step + 1;
-            
+
             // Encode new state
             out_state.extend_from_slice(&new_step.to_le_bytes());
-            
+
             // Encode new observation
             out_obs.extend_from_slice(&(new_step as f32).to_le_bytes());
-            
+
             let reward = 1.0;
             let done = new_step >= 5;
-            
-            Ok((reward, done))
+
+            let info = new_step as u64;
+
+            Ok((reward, done, info))
         }
     }
 
@@ -200,56 +204,64 @@ mod tests {
         let mut game = MockErasedGame::new();
         let mut state_buf = Vec::new();
         let mut obs_buf = Vec::new();
-        
+
         game.reset(42, &[], &mut state_buf, &mut obs_buf).unwrap();
-        
+
         assert_eq!(state_buf.len(), 4);
         assert_eq!(obs_buf.len(), 4);
-        
+
         let state = u32::from_le_bytes(state_buf.try_into().unwrap());
         assert_eq!(state, 0);
     }
-    
+
     #[test]
     fn test_erased_game_step() {
         let mut game = MockErasedGame::new();
         let mut state_buf = Vec::new();
         let mut obs_buf = Vec::new();
-        
+
         // Reset first
         game.reset(42, &[], &mut state_buf, &mut obs_buf).unwrap();
-        
+
         // Take a step
         let action_bytes = vec![0]; // Mock action
         let mut new_state_buf = Vec::new();
         let mut new_obs_buf = Vec::new();
-        
-        let (reward, done) = game.step(&state_buf, &action_bytes, &mut new_state_buf, &mut new_obs_buf).unwrap();
-        
+
+        let (reward, done, info) = game
+            .step(
+                &state_buf,
+                &action_bytes,
+                &mut new_state_buf,
+                &mut new_obs_buf,
+            )
+            .unwrap();
+
         assert_eq!(reward, 1.0);
         assert!(!done);
+        assert_eq!(info, 1);
         assert_eq!(new_state_buf.len(), 4);
         assert_eq!(new_obs_buf.len(), 4);
-        
+
         let new_state = u32::from_le_bytes(new_state_buf.try_into().unwrap());
         assert_eq!(new_state, 1);
     }
-    
+
     #[test]
     fn test_erased_game_capabilities() {
         let game = MockErasedGame::new();
         let caps = game.capabilities();
-        
+
         assert_eq!(caps.id.env_id, "mock");
         assert_eq!(caps.max_horizon, 10);
         assert_eq!(caps.encoding.state, "u32:v1");
-        
+
         match caps.action_space {
             ActionSpace::Discrete(n) => assert_eq!(n, 2),
             _ => panic!("Expected discrete action space"),
         }
     }
-    
+
     #[test]
     fn test_invalid_state_error() {
         let mut game = MockErasedGame::new();
@@ -257,9 +269,9 @@ mod tests {
         let action_bytes = vec![0];
         let mut state_buf = Vec::new();
         let mut obs_buf = Vec::new();
-        
+
         let result = game.step(&invalid_state, &action_bytes, &mut state_buf, &mut obs_buf);
-        
+
         assert!(result.is_err());
         match result.unwrap_err() {
             ErasedGameError::InvalidState(msg) => {

--- a/services/engine-rust/engine-core/src/typed.rs
+++ b/services/engine-rust/engine-core/src/typed.rs
@@ -1,5 +1,5 @@
 //! Typed Game trait providing ergonomic interface for game developers
-//! 
+//!
 //! This trait allows game implementations to work with strongly-typed state,
 //! action, and observation types while maintaining compile-time type safety.
 
@@ -26,7 +26,11 @@ pub struct Encoding {
 pub enum ActionSpace {
     Discrete(u32),
     MultiDiscrete(Vec<u32>),
-    Continuous { low: Vec<f32>, high: Vec<f32>, shape: Vec<u32> },
+    Continuous {
+        low: Vec<f32>,
+        high: Vec<f32>,
+        shape: Vec<u32>,
+    },
 }
 
 /// Game capabilities and configuration
@@ -40,42 +44,42 @@ pub struct Capabilities {
 }
 
 /// Main trait for game implementations
-/// 
+///
 /// Games should implement this trait with their specific types for State, Action, and Obs.
 /// The trait provides compile-time type safety while allowing conversion to the erased
 /// interface for runtime polymorphism.
-/// 
+///
 /// # Type Parameters
-/// 
+///
 /// * `State` - Game state type, should be POD-like for efficient copying
 /// * `Action` - Action type, should be small and Copy or compact
 /// * `Obs` - Observation type, often contiguous arrays of f32
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust
 /// # use engine_core::typed::*;
 /// # use rand_chacha::ChaCha20Rng;
-/// 
+///
 /// #[derive(Clone, Copy)]
 /// struct TicTacToeState {
 ///     board: [u8; 9],
 ///     current_player: u8,
 /// }
-/// 
+///
 /// #[derive(Clone, Copy)]
 /// enum TicTacToeAction {
 ///     Place(u8),
 /// }
-/// 
+///
 /// #[derive(Clone)]
 /// struct TicTacToeObs {
 ///     board_view: [f32; 18],
 ///     legal_moves: [f32; 9],
 /// }
-/// 
+///
 /// struct TicTacToe;
-/// 
+///
 /// impl Game for TicTacToe {
 ///     type State = TicTacToeState;
 ///     type Action = TicTacToeAction;
@@ -85,7 +89,12 @@ pub struct Capabilities {
 /// #   fn engine_id(&self) -> EngineId { todo!() }
 /// #   fn capabilities(&self) -> Capabilities { todo!() }
 /// #   fn reset(&mut self, rng: &mut ChaCha20Rng, hint: &[u8]) -> (Self::State, Self::Obs) { todo!() }
-/// #   fn step(&mut self, state: &mut Self::State, action: Self::Action, rng: &mut ChaCha20Rng) -> (Self::Obs, f32, bool) { todo!() }
+/// #   fn step(
+/// #       &mut self,
+/// #       state: &mut Self::State,
+/// #       action: Self::Action,
+/// #       rng: &mut ChaCha20Rng,
+/// #   ) -> (Self::Obs, f32, bool, u64) { todo!() }
 /// #   fn encode_state(state: &Self::State, out: &mut Vec<u8>) -> Result<(), EncodeError> { todo!() }
 /// #   fn decode_state(buf: &[u8]) -> Result<Self::State, DecodeError> { todo!() }
 /// #   fn encode_action(action: &Self::Action, out: &mut Vec<u8>) -> Result<(), EncodeError> { todo!() }
@@ -96,58 +105,63 @@ pub struct Capabilities {
 pub trait Game: Send + Sync + 'static {
     /// Game state type - should be efficiently copyable
     type State: Send + Sync + 'static;
-    
+
     /// Action type - should be small and Copy or compact
     type Action: Send + Sync + 'static;
-    
+
     /// Observation type - often contiguous arrays of f32
     type Obs: Send + Sync + 'static;
 
     /// Get engine identification information
     fn engine_id(&self) -> EngineId;
-    
+
     /// Get game capabilities and configuration
     fn capabilities(&self) -> Capabilities;
-    
+
     /// Reset the game to initial state
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `rng` - Deterministic random number generator for reproducible resets
     /// * `hint` - Optional hint data for environment setup
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A tuple of (initial_state, initial_observation)
     fn reset(&mut self, rng: &mut ChaCha20Rng, hint: &[u8]) -> (Self::State, Self::Obs);
-    
+
     /// Perform one simulation step
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `state` - Current game state (mutable for in-place updates)
     /// * `action` - Action to take
     /// * `rng` - Random number generator for stochastic elements
-    /// 
+    ///
     /// # Returns
-    /// 
-    /// A tuple of (observation, reward, done)
-    fn step(&mut self, state: &mut Self::State, action: Self::Action, rng: &mut ChaCha20Rng) -> (Self::Obs, f32, bool);
+    ///
+    /// A tuple of (observation, reward, done, info)
+    fn step(
+        &mut self,
+        state: &mut Self::State,
+        action: Self::Action,
+        rng: &mut ChaCha20Rng,
+    ) -> (Self::Obs, f32, bool, u64);
 
     // Encoding/Decoding hooks for serialization
-    
+
     /// Encode state to bytes
     fn encode_state(state: &Self::State, out: &mut Vec<u8>) -> Result<(), EncodeError>;
-    
+
     /// Decode state from bytes
     fn decode_state(buf: &[u8]) -> Result<Self::State, DecodeError>;
-    
+
     /// Encode action to bytes
     fn encode_action(action: &Self::Action, out: &mut Vec<u8>) -> Result<(), EncodeError>;
-    
+
     /// Decode action from bytes
     fn decode_action(buf: &[u8]) -> Result<Self::Action, DecodeError>;
-    
+
     /// Encode observation to bytes
     fn encode_obs(obs: &Self::Obs, out: &mut Vec<u8>) -> Result<(), EncodeError>;
 }
@@ -184,27 +198,27 @@ mod tests {
     // Helper types for testing
     #[derive(Clone, Copy, Debug, PartialEq)]
     struct TestState(u32);
-    
+
     #[derive(Clone, Copy, Debug, PartialEq)]
     struct TestAction(u8);
-    
+
     #[derive(Clone, Debug, PartialEq)]
     struct TestObs(Vec<f32>);
-    
+
     struct TestGame;
-    
+
     impl Game for TestGame {
         type State = TestState;
         type Action = TestAction;
         type Obs = TestObs;
-        
+
         fn engine_id(&self) -> EngineId {
             EngineId {
                 env_id: "test".to_string(),
                 build_id: "0.1.0".to_string(),
             }
         }
-        
+
         fn capabilities(&self) -> Capabilities {
             Capabilities {
                 id: self.engine_id(),
@@ -219,41 +233,57 @@ mod tests {
                 preferred_batch: 32,
             }
         }
-        
+
         fn reset(&mut self, _rng: &mut ChaCha20Rng, _hint: &[u8]) -> (Self::State, Self::Obs) {
             (TestState(0), TestObs(vec![0.0, 1.0]))
         }
-        
-        fn step(&mut self, state: &mut Self::State, action: Self::Action, _rng: &mut ChaCha20Rng) -> (Self::Obs, f32, bool) {
+
+        fn step(
+            &mut self,
+            state: &mut Self::State,
+            action: Self::Action,
+            _rng: &mut ChaCha20Rng,
+        ) -> (Self::Obs, f32, bool, u64) {
             state.0 += action.0 as u32;
-            (TestObs(vec![state.0 as f32]), 1.0, state.0 >= 10)
+            (
+                TestObs(vec![state.0 as f32]),
+                1.0,
+                state.0 >= 10,
+                state.0 as u64,
+            )
         }
-        
+
         fn encode_state(state: &Self::State, out: &mut Vec<u8>) -> Result<(), EncodeError> {
             out.extend_from_slice(&state.0.to_le_bytes());
             Ok(())
         }
-        
+
         fn decode_state(buf: &[u8]) -> Result<Self::State, DecodeError> {
             if buf.len() != 4 {
-                return Err(DecodeError::InvalidLength { expected: 4, actual: buf.len() });
+                return Err(DecodeError::InvalidLength {
+                    expected: 4,
+                    actual: buf.len(),
+                });
             }
             let value = u32::from_le_bytes(buf.try_into().unwrap());
             Ok(TestState(value))
         }
-        
+
         fn encode_action(action: &Self::Action, out: &mut Vec<u8>) -> Result<(), EncodeError> {
             out.push(action.0);
             Ok(())
         }
-        
+
         fn decode_action(buf: &[u8]) -> Result<Self::Action, DecodeError> {
             if buf.len() != 1 {
-                return Err(DecodeError::InvalidLength { expected: 1, actual: buf.len() });
+                return Err(DecodeError::InvalidLength {
+                    expected: 1,
+                    actual: buf.len(),
+                });
             }
             Ok(TestAction(buf[0]))
         }
-        
+
         fn encode_obs(obs: &Self::Obs, out: &mut Vec<u8>) -> Result<(), EncodeError> {
             for &value in &obs.0 {
                 out.extend_from_slice(&value.to_le_bytes());
@@ -266,35 +296,47 @@ mod tests {
     fn test_game_basic_functionality() {
         let mut game = TestGame;
         let mut rng = ChaCha20Rng::seed_from_u64(42);
-        
+
         let (state, obs) = game.reset(&mut rng, &[]);
         assert_eq!(state, TestState(0));
         assert_eq!(obs, TestObs(vec![0.0, 1.0]));
-        
+
         let caps = game.capabilities();
         assert_eq!(caps.id.env_id, "test");
         assert_eq!(caps.max_horizon, 100);
     }
-    
+
     #[test]
     fn test_state_encoding_roundtrip() {
         let state = TestState(42);
         let mut buf = Vec::new();
-        
+
         TestGame::encode_state(&state, &mut buf).unwrap();
         let decoded = TestGame::decode_state(&buf).unwrap();
-        
+
         assert_eq!(state, decoded);
     }
-    
+
     #[test]
     fn test_action_encoding_roundtrip() {
         let action = TestAction(3);
         let mut buf = Vec::new();
-        
+
         TestGame::encode_action(&action, &mut buf).unwrap();
         let decoded = TestGame::decode_action(&buf).unwrap();
-        
+
         assert_eq!(action, decoded);
+    }
+
+    #[test]
+    fn test_step_returns_info_bits() {
+        let mut game = TestGame;
+        let mut rng = ChaCha20Rng::seed_from_u64(7);
+        let mut state = TestState(0);
+
+        let (_obs, _reward, done, info) = game.step(&mut state, TestAction(2), &mut rng);
+
+        assert!(!done);
+        assert_eq!(info, state.0 as u64);
     }
 }

--- a/services/engine-rust/engine-proto/src/engine.v1.rs
+++ b/services/engine-rust/engine-proto/src/engine.v1.rs
@@ -141,6 +141,9 @@ pub struct StepResponse {
     /// Whether episode has terminated
     #[prost(bool, tag = "4")]
     pub done: bool,
+    /// Additional packed info bits (game-specific semantics)
+    #[prost(uint64, tag = "5")]
+    pub info: u64,
 }
 /// Single trajectory configuration for batch simulation
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/services/engine-rust/games-tictactoe/benches/engine.rs
+++ b/services/engine-rust/games-tictactoe/benches/engine.rs
@@ -1,0 +1,72 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use engine_core::Game;
+use games_tictactoe::{Action, Observation, State, TicTacToe};
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+fn bench_reset(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tictactoe_reset");
+    group.bench_function("reset", |b| {
+        let mut game = TicTacToe::new();
+        b.iter_batched(
+            || ChaCha20Rng::seed_from_u64(42),
+            |mut rng| {
+                let _ = game.reset(&mut rng, &[]);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_step(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tictactoe_step");
+    group.bench_function("step_center", |b| {
+        let mut game = TicTacToe::new();
+        let mut rng = ChaCha20Rng::seed_from_u64(7);
+        let (mut base_state, _) = game.reset(&mut rng, &[]);
+        b.iter_batched(
+            || base_state,
+            |mut state| {
+                let action = Action::Place(4);
+                let _ = game.step(&mut state, action, &mut rng);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_encode_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tictactoe_encoding");
+
+    group.bench_function("state_roundtrip", |b| {
+        let state = State::new();
+        b.iter_batched(
+            || Vec::with_capacity(16),
+            |mut buffer| {
+                TicTacToe::encode_state(&state, &mut buffer).unwrap();
+                let _ = TicTacToe::decode_state(&buffer).unwrap();
+                buffer
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("observation_encode", |b| {
+        let obs = Observation::from_state(&State::new());
+        b.iter_batched(
+            || Vec::with_capacity(128),
+            |mut buffer| {
+                TicTacToe::encode_obs(&obs, &mut buffer).unwrap();
+                buffer
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_reset, bench_step, bench_encode_decode);
+criterion_main!(benches);

--- a/services/engine-rust/games-tictactoe/src/lib.rs
+++ b/services/engine-rust/games-tictactoe/src/lib.rs
@@ -1,13 +1,15 @@
 //! TicTacToe game implementation for the Cartridge engine
-//! 
+//!
 //! This crate provides a complete reference implementation of TicTacToe
 //! demonstrating how to implement the Game trait for the engine framework.
 
-use engine_core::typed::{Game, EngineId, Capabilities, Encoding, ActionSpace, EncodeError, DecodeError};
+use engine_core::typed::{
+    ActionSpace, Capabilities, DecodeError, EncodeError, Encoding, EngineId, Game,
+};
 use rand_chacha::ChaCha20Rng;
 
 /// TicTacToe game state
-/// 
+///
 /// Represents the complete state of a TicTacToe game including the board,
 /// current player, and winner information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,62 +31,90 @@ impl State {
             winner: 0,
         }
     }
-    
+
     /// Check if the game is over
     pub fn is_done(&self) -> bool {
         self.winner != 0
     }
-    
+
     /// Get legal moves (empty positions)
     pub fn legal_moves(&self) -> Vec<u8> {
         if self.is_done() {
             return Vec::new();
         }
-        
-        (0..9u8).filter(|&pos| self.board[pos as usize] == 0).collect()
+
+        (0..9u8)
+            .filter(|&pos| self.board[pos as usize] == 0)
+            .collect()
     }
-    
+
+    /// Bit-mask representation of legal moves.
+    ///
+    /// Bits 0-8 correspond to board positions 0-8. A bit set to 1 indicates the
+    /// position is currently legal. When the game is finished the mask is zeroed.
+    pub fn legal_moves_mask(&self) -> u16 {
+        if self.is_done() {
+            return 0;
+        }
+
+        self.board
+            .iter()
+            .enumerate()
+            .fold(0u16, |mask, (idx, cell)| {
+                if *cell == 0 {
+                    mask | (1u16 << idx)
+                } else {
+                    mask
+                }
+            })
+    }
+
     /// Make a move and return the new state
     pub fn make_move(&self, position: u8) -> State {
         if self.is_done() || position >= 9 || self.board[position as usize] != 0 {
             return *self; // Invalid move, return unchanged state
         }
-        
+
         let mut new_state = *self;
         new_state.board[position as usize] = self.current_player;
-        
+
         // Check for winner
         new_state.winner = Self::check_winner(&new_state.board);
-        
+
         // Switch player if game not over
         if new_state.winner == 0 {
             new_state.current_player = if self.current_player == 1 { 2 } else { 1 };
         }
-        
+
         new_state
     }
-    
+
     /// Check for winner on the board
     fn check_winner(board: &[u8; 9]) -> u8 {
         // Winning positions (rows, columns, diagonals)
         const LINES: [[usize; 3]; 8] = [
-            [0, 1, 2], [3, 4, 5], [6, 7, 8], // rows
-            [0, 3, 6], [1, 4, 7], [2, 5, 8], // columns
-            [0, 4, 8], [2, 4, 6],           // diagonals
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8], // rows
+            [0, 3, 6],
+            [1, 4, 7],
+            [2, 5, 8], // columns
+            [0, 4, 8],
+            [2, 4, 6], // diagonals
         ];
-        
+
         for line in &LINES {
             let [a, b, c] = *line;
             if board[a] != 0 && board[a] == board[b] && board[b] == board[c] {
                 return board[a]; // Return the winning player
             }
         }
-        
+
         // Check for draw (board full but no winner)
         if board.iter().all(|&cell| cell != 0) {
             return 3; // Draw
         }
-        
+
         0 // Game ongoing
     }
 }
@@ -112,7 +142,7 @@ impl Action {
 }
 
 /// TicTacToe observation
-/// 
+///
 /// Provides a neural network-friendly representation of the game state
 /// including board state and legal move mask.
 #[derive(Debug, Clone, PartialEq)]
@@ -131,7 +161,7 @@ impl Observation {
         let mut board_view = [0.0; 18];
         let mut legal_moves = [0.0; 9];
         let mut current_player = [0.0; 2];
-        
+
         // Encode board state (one-hot for X and O)
         for (i, &cell) in state.board.iter().enumerate() {
             if cell == 1 {
@@ -140,21 +170,22 @@ impl Observation {
                 board_view[i + 9] = 1.0; // O positions
             }
         }
-        
+
         // Encode legal moves
-        if !state.is_done() {
-            for pos in state.legal_moves() {
-                legal_moves[pos as usize] = 1.0;
+        let mask = state.legal_moves_mask();
+        for pos in 0..9 {
+            if (mask & (1u16 << pos)) != 0 {
+                legal_moves[pos] = 1.0;
             }
         }
-        
+
         // Encode current player
         if state.current_player == 1 {
             current_player[0] = 1.0; // X
         } else {
             current_player[1] = 1.0; // O
         }
-        
+
         Self {
             board_view,
             legal_moves,
@@ -172,16 +203,50 @@ impl TicTacToe {
     pub fn new() -> Self {
         Self
     }
-    
+
     /// Calculate reward for the current state
     fn calculate_reward(state: &State, previous_player: u8) -> f32 {
         match state.winner {
-            0 => 0.0,    // Game ongoing
-            1 => if previous_player == 1 { 1.0 } else { -1.0 }, // X wins
-            2 => if previous_player == 2 { 1.0 } else { -1.0 }, // O wins  
-            3 => 0.0,    // Draw
-            _ => 0.0,    // Shouldn't happen
+            0 => 0.0, // Game ongoing
+            1 => {
+                if previous_player == 1 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            } // X wins
+            2 => {
+                if previous_player == 2 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            } // O wins
+            3 => 0.0, // Draw
+            _ => 0.0, // Shouldn't happen
         }
+    }
+
+    /// Pack auxiliary information about the state into a u64 bit-field.
+    ///
+    /// Layout (little endian bit numbering):
+    /// * Bits 0-8  : Legal move mask
+    /// * Bits 16-19: Current player (1 = X, 2 = O)
+    /// * Bits 20-23: Winner (0 = none, 1 = X, 2 = O, 3 = draw)
+    /// * Bits 24-27: Moves played so far
+    fn compute_info_bits(state: &State) -> u64 {
+        const CURRENT_PLAYER_SHIFT: u32 = 16;
+        const WINNER_SHIFT: u32 = 20;
+        const MOVES_PLAYED_SHIFT: u32 = 24;
+
+        let mut info = state.legal_moves_mask() as u64;
+        info |= (state.current_player as u64) << CURRENT_PLAYER_SHIFT;
+        info |= (state.winner as u64) << WINNER_SHIFT;
+
+        let moves_played = state.board.iter().filter(|&&cell| cell != 0).count() as u64;
+        info |= moves_played << MOVES_PLAYED_SHIFT;
+
+        info
     }
 }
 
@@ -195,14 +260,14 @@ impl Game for TicTacToe {
     type State = State;
     type Action = Action;
     type Obs = Observation;
-    
+
     fn engine_id(&self) -> EngineId {
         EngineId {
             env_id: "tictactoe".to_string(),
             build_id: env!("CARGO_PKG_VERSION").to_string(),
         }
     }
-    
+
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             id: self.engine_id(),
@@ -212,29 +277,35 @@ impl Game for TicTacToe {
                 obs: "f32x29:v1".to_string(), // 18 + 9 + 2 = 29 floats
                 schema_version: 1,
             },
-            max_horizon: 9, // Maximum 9 moves in TicTacToe
+            max_horizon: 9,                         // Maximum 9 moves in TicTacToe
             action_space: ActionSpace::Discrete(9), // 9 possible positions
             preferred_batch: 64,
         }
     }
-    
+
     fn reset(&mut self, _rng: &mut ChaCha20Rng, _hint: &[u8]) -> (Self::State, Self::Obs) {
         let state = State::new();
         let obs = Observation::from_state(&state);
         (state, obs)
     }
-    
-    fn step(&mut self, state: &mut Self::State, action: Self::Action, _rng: &mut ChaCha20Rng) -> (Self::Obs, f32, bool) {
+
+    fn step(
+        &mut self,
+        state: &mut Self::State,
+        action: Self::Action,
+        _rng: &mut ChaCha20Rng,
+    ) -> (Self::Obs, f32, bool, u64) {
         let previous_player = state.current_player;
         *state = state.make_move(action.position());
-        
+
         let obs = Observation::from_state(state);
         let reward = Self::calculate_reward(state, previous_player);
         let done = state.is_done();
-        
-        (obs, reward, done)
+        let info = Self::compute_info_bits(state);
+
+        (obs, reward, done, info)
     }
-    
+
     fn encode_state(state: &Self::State, out: &mut Vec<u8>) -> Result<(), EncodeError> {
         // Simple binary encoding: board (9 bytes) + current_player (1 byte) + winner (1 byte)
         out.extend_from_slice(&state.board);
@@ -242,78 +313,83 @@ impl Game for TicTacToe {
         out.push(state.winner);
         Ok(())
     }
-    
+
     fn decode_state(buf: &[u8]) -> Result<Self::State, DecodeError> {
         if buf.len() != 11 {
-            return Err(DecodeError::InvalidLength { 
-                expected: 11, 
-                actual: buf.len() 
+            return Err(DecodeError::InvalidLength {
+                expected: 11,
+                actual: buf.len(),
             });
         }
-        
+
         let mut board = [0u8; 9];
         board.copy_from_slice(&buf[0..9]);
-        
+
         let current_player = buf[9];
         let winner = buf[10];
-        
+
         // Validate the state
         if current_player != 1 && current_player != 2 {
-            return Err(DecodeError::CorruptedData(
-                format!("Invalid current_player: {}", current_player)
-            ));
+            return Err(DecodeError::CorruptedData(format!(
+                "Invalid current_player: {}",
+                current_player
+            )));
         }
-        
+
         if winner > 3 {
-            return Err(DecodeError::CorruptedData(
-                format!("Invalid winner: {}", winner)
-            ));
+            return Err(DecodeError::CorruptedData(format!(
+                "Invalid winner: {}",
+                winner
+            )));
         }
-        
+
         for &cell in &board {
             if cell > 2 {
-                return Err(DecodeError::CorruptedData(
-                    format!("Invalid board cell: {}", cell)
-                ));
+                return Err(DecodeError::CorruptedData(format!(
+                    "Invalid board cell: {}",
+                    cell
+                )));
             }
         }
-        
+
         Ok(State {
             board,
             current_player,
             winner,
         })
     }
-    
+
     fn encode_action(action: &Self::Action, out: &mut Vec<u8>) -> Result<(), EncodeError> {
         let position = action.position();
         if position >= 9 {
-            return Err(EncodeError::InvalidData(
-                format!("Invalid action position: {}", position)
-            ));
+            return Err(EncodeError::InvalidData(format!(
+                "Invalid action position: {}",
+                position
+            )));
         }
         out.push(position);
         Ok(())
     }
-    
+
     fn decode_action(buf: &[u8]) -> Result<Self::Action, DecodeError> {
         if buf.len() != 1 {
-            return Err(DecodeError::InvalidLength { 
-                expected: 1, 
-                actual: buf.len() 
+            return Err(DecodeError::InvalidLength {
+                expected: 1,
+                actual: buf.len(),
             });
         }
-        
+
         let position = buf[0];
         if position >= 9 {
-            return Err(DecodeError::CorruptedData(
-                format!("Invalid action position: {}", position)
-            ));
+            return Err(DecodeError::CorruptedData(format!(
+                "Invalid action position: {}",
+                position
+            )));
         }
-        
+
         Ok(Action::Place(position))
     }
-    
+
     fn encode_obs(obs: &Self::Obs, out: &mut Vec<u8>) -> Result<(), EncodeError> {
         // Encode as 29 f32 values in little-endian format
         for &value in &obs.board_view {
@@ -333,7 +409,7 @@ impl Game for TicTacToe {
 mod tests {
     use super::*;
     use rand::SeedableRng;
-    
+
     #[test]
     fn test_initial_state() {
         let state = State::new();
@@ -342,64 +418,66 @@ mod tests {
         assert_eq!(state.winner, 0);
         assert!(!state.is_done());
     }
-    
+
     #[test]
     fn test_legal_moves() {
         let state = State::new();
         let legal = state.legal_moves();
         assert_eq!(legal, (0..9).collect::<Vec<_>>());
-        
+        assert_eq!(state.legal_moves_mask(), 0x1FFu16);
+
         // After one move
         let state = state.make_move(4); // Center
         let legal = state.legal_moves();
         assert_eq!(legal.len(), 8);
         assert!(!legal.contains(&4));
+        assert_eq!(state.legal_moves_mask(), 0x1FFu16 & !(1u16 << 4));
     }
-    
+
     #[test]
     fn test_make_move() {
         let state = State::new();
         let new_state = state.make_move(4); // X places in center
-        
+
         assert_eq!(new_state.board[4], 1);
         assert_eq!(new_state.current_player, 2); // Now O's turn
         assert!(!new_state.is_done());
     }
-    
+
     #[test]
     fn test_invalid_move() {
         let state = State::new();
         let state_with_move = state.make_move(4);
-        
+
         // Try to place in same position
         let invalid_state = state_with_move.make_move(4);
         assert_eq!(invalid_state, state_with_move); // Should be unchanged
     }
-    
+
     #[test]
     fn test_winning_game() {
         let mut state = State::new();
-        
+
         // X wins with top row
         state = state.make_move(0); // X
         state = state.make_move(3); // O
         state = state.make_move(1); // X
         state = state.make_move(4); // O
         state = state.make_move(2); // X wins
-        
+
         assert_eq!(state.winner, 1);
         assert!(state.is_done());
         assert!(state.legal_moves().is_empty());
     }
-    
+
     #[test]
     fn test_draw_game() {
         // Create a draw state manually since getting the exact move sequence is tricky
         // Board: X O X / O X O / O X O
         let state = State {
             board: [1, 2, 1, 2, 1, 2, 2, 1, 2], // X=1, O=2
-            current_player: 1, // Doesn't matter since game is over
-            winner: 3, // This should be detected as a draw
+            current_player: 1,                  // Doesn't matter since game is over
+            winner: 3,                          // This should be detected as a draw
         };
 
         // Verify this is actually a draw by checking the game logic
@@ -407,12 +485,12 @@ mod tests {
         assert_eq!(detected_winner, 3); // Should be draw
         assert!(state.is_done());
     }
-    
+
     #[test]
     fn test_observation_encoding() {
         let state = State::new();
         let obs = Observation::from_state(&state);
-        
+
         // All board positions should be 0 initially
         assert_eq!(obs.board_view, [0.0; 18]);
         // All moves should be legal
@@ -420,24 +498,29 @@ mod tests {
         // X should be current player
         assert_eq!(obs.current_player, [1.0, 0.0]);
     }
-    
+
     #[test]
     fn test_game_trait_implementation() {
         let mut game = TicTacToe::new();
         let mut rng = ChaCha20Rng::seed_from_u64(42);
-        
+
         let (state, _obs) = game.reset(&mut rng, &[]);
         assert_eq!(state, State::new());
-        
+
         let action = Action::Place(4);
-        let (_new_obs, reward, done) = game.step(&mut state.clone(), action, &mut rng);
-        
+        let (_new_obs, reward, done, info) = game.step(&mut state.clone(), action, &mut rng);
+
         // Should not be done after one move
         assert!(!done);
         // Reward should be 0 for ongoing game
         assert_eq!(reward, 0.0);
+
+        // Mask should no longer include the center position
+        assert_eq!(info & 0x1FF, 0x1FFu64 & !(1u64 << 4));
+        // Next player should be O (value 2)
+        assert_eq!((info >> 16) & 0xF, 2);
     }
-    
+
     #[test]
     fn test_state_encoding_roundtrip() {
         let original_state = State {
@@ -445,25 +528,25 @@ mod tests {
             current_player: 2,
             winner: 0,
         };
-        
+
         let mut buf = Vec::new();
         TicTacToe::encode_state(&original_state, &mut buf).unwrap();
         let decoded_state = TicTacToe::decode_state(&buf).unwrap();
-        
+
         assert_eq!(original_state, decoded_state);
     }
-    
+
     #[test]
     fn test_action_encoding_roundtrip() {
         let action = Action::Place(5);
-        
+
         let mut buf = Vec::new();
         TicTacToe::encode_action(&action, &mut buf).unwrap();
         let decoded_action = TicTacToe::decode_action(&buf).unwrap();
-        
+
         assert_eq!(action, decoded_action);
     }
-    
+
     #[test]
     fn test_observation_byte_encoding() {
         let state = State {
@@ -479,34 +562,34 @@ mod tests {
         // Should be 29 * 4 = 116 bytes (29 f32 values)
         assert_eq!(buf.len(), 116);
     }
-    
+
     #[test]
     fn test_engine_capabilities() {
         let game = TicTacToe::new();
         let caps = game.capabilities();
-        
+
         assert_eq!(caps.id.env_id, "tictactoe");
         assert_eq!(caps.max_horizon, 9);
-        
+
         match caps.action_space {
             ActionSpace::Discrete(n) => assert_eq!(n, 9),
             _ => panic!("Expected discrete action space"),
         }
     }
-    
+
     #[test]
     fn test_invalid_state_decoding() {
         // Test wrong length
         let buf = vec![1, 2, 3]; // Too short
         let result = TicTacToe::decode_state(&buf);
         assert!(result.is_err());
-        
+
         // Test invalid current_player
         let mut buf = vec![0; 11];
         buf[9] = 5; // Invalid player
         let result = TicTacToe::decode_state(&buf);
         assert!(result.is_err());
-        
+
         // Test invalid winner
         let mut buf = vec![0; 11];
         buf[9] = 1; // Valid player
@@ -514,17 +597,34 @@ mod tests {
         let result = TicTacToe::decode_state(&buf);
         assert!(result.is_err());
     }
-    
+
     #[test]
     fn test_invalid_action_decoding() {
         // Test wrong length
         let buf = vec![1, 2]; // Too long
         let result = TicTacToe::decode_action(&buf);
         assert!(result.is_err());
-        
+
         // Test invalid position
         let buf = vec![9]; // Position out of bounds
         let result = TicTacToe::decode_action(&buf);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_info_bits_encoding() {
+        let state = State {
+            board: [1, 2, 1, 0, 2, 0, 0, 0, 0],
+            current_player: 1,
+            winner: 0,
+        };
+
+        let info = TicTacToe::compute_info_bits(&state);
+
+        assert_eq!(info & 0x1FF, state.legal_moves_mask() as u64);
+        assert_eq!((info >> 16) & 0xF, state.current_player as u64);
+        assert_eq!((info >> 20) & 0xF, state.winner as u64);
+        // Four occupied squares
+        assert_eq!((info >> 24) & 0xF, 4);
     }
 }


### PR DESCRIPTION
## Summary
- add an `info` bit-field to the StepResponse protobuf and thread it through the erased/typed engine traits
- teach the TicTacToe reference game to expose legal move masks and packed info bits while strengthening encode/decode tests
- add Criterion benches that cover reset, step, and encode/decode hot paths for the TicTacToe implementation

## Testing
- cargo test --manifest-path services/engine-rust/games-tictactoe/Cargo.toml *(fails: workspace member `/workspace/Cartridge/services/actor-rust/Cargo.toml` is not hierarchically below the workspace root)*
- cargo test --manifest-path services/engine-rust/engine-core/Cargo.toml *(fails: workspace member `/workspace/Cartridge/services/actor-rust/Cargo.toml` is not hierarchically below the workspace root)*

------
https://chatgpt.com/codex/tasks/task_e_68dae1b5e3088330ba818f9d7570dea1