### PR TITLE
Scaffold learner service skeleton

### DIFF
--- a/services/learner-py/README.md
+++ b/services/learner-py/README.md
@@ -1,0 +1,5 @@
+# Cartridge Learner Service
+
+This package implements the learner component described in the `docs/Individual Component Design/LEARNER.md`
+specification. The initial scaffolding focuses on configuration loading, replay integration surfaces, and
+training loop orchestration so that we can iteratively add algorithm details.

--- a/services/learner-py/learner/__init__.py
+++ b/services/learner-py/learner/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for the Cartridge learner service."""
+
+from .config import LearnerConfig, load_config
+from .main import run
+
+__all__ = ["LearnerConfig", "load_config", "run"]

--- a/services/learner-py/learner/algo/__init__.py
+++ b/services/learner-py/learner/algo/__init__.py
@@ -1,0 +1,5 @@
+"""Algorithm registry for the learner."""
+
+from .registry import AlgorithmFactory, AlgorithmProtocol, get_algorithm
+
+__all__ = ["AlgorithmFactory", "AlgorithmProtocol", "get_algorithm"]

--- a/services/learner-py/learner/algo/networks.py
+++ b/services/learner-py/learner/algo/networks.py
@@ -1,0 +1,48 @@
+"""Model definitions used by learner algorithms."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+from torch.distributions import Categorical, Distribution
+
+
+class ActorCriticNetwork(nn.Module):
+    """Simple shared-body actor-critic network."""
+
+    def __init__(
+        self,
+        observation_dim: int,
+        action_dim: int,
+        hidden_sizes: Sequence[int] = (256, 256),
+        activation: type[nn.Module] = nn.Tanh,
+    ) -> None:
+        super().__init__()
+        layers: list[nn.Module] = []
+        input_dim = observation_dim
+        for size in hidden_sizes:
+            layers.append(nn.Linear(input_dim, size))
+            layers.append(activation())
+            input_dim = size
+        self.body = nn.Sequential(*layers)
+        self.policy_head = nn.Linear(input_dim, action_dim)
+        self.value_head = nn.Linear(input_dim, 1)
+
+        self._init_parameters()
+
+    def forward(self, observations: torch.Tensor) -> tuple[Distribution, torch.Tensor]:
+        features = self.body(observations)
+        logits = self.policy_head(features)
+        value = self.value_head(features).squeeze(-1)
+        return Categorical(logits=logits), value
+
+    def _init_parameters(self) -> None:
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                nn.init.orthogonal_(module.weight, gain=nn.init.calculate_gain("tanh"))
+                nn.init.zeros_(module.bias)
+
+
+__all__ = ["ActorCriticNetwork"]

--- a/services/learner-py/learner/algo/ppo.py
+++ b/services/learner-py/learner/algo/ppo.py
@@ -1,0 +1,111 @@
+"""Proximal Policy Optimisation implementation."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.optim import Adam
+
+from ..config import AlgorithmConfig, TrainingConfig
+from ..datamodel import AlgorithmUpdate, TransitionBatch
+from ..utils.math import compute_gae
+from .networks import ActorCriticNetwork
+from .registry import AlgorithmProtocol, register
+
+
+class PPOLearner(AlgorithmProtocol):
+    """Minimal PPO implementation matching the design document."""
+
+    def __init__(self, config: AlgorithmConfig, training: TrainingConfig) -> None:
+        self._config = config
+        self._training = training
+        self._device = torch.device(training.device)
+        self._model = ActorCriticNetwork(
+            observation_dim=training.observation_dim,
+            action_dim=training.action_dim,
+        ).to(self._device)
+        self._optimizer = Adam(self._model.parameters(), lr=training.learning_rate)
+        self._step = 0
+
+    def update(self, batch: TransitionBatch) -> AlgorithmUpdate:
+        self._model.train()
+        batch = batch.to_device(self._device)
+        advantages, returns = self._ensure_advantages(batch)
+
+        observations = batch.observations
+        actions = batch.actions
+        old_log_probs = batch.log_probs
+
+        flat_obs = observations.view(-1, observations.shape[-1])
+        flat_actions = actions.view(-1)
+        flat_old_log_probs = old_log_probs.view(-1)
+        flat_advantages = advantages.view(-1)
+        flat_returns = returns.view(-1)
+
+        flat_advantages = (flat_advantages - flat_advantages.mean()) / (
+            flat_advantages.std(unbiased=False) + 1e-8
+        )
+
+        dist, values = self._model(flat_obs)
+        log_probs = dist.log_prob(flat_actions)
+        ratio = torch.exp(log_probs - flat_old_log_probs)
+        clipped_ratio = torch.clamp(
+            ratio, 1.0 - self._config.clip_ratio, 1.0 + self._config.clip_ratio
+        )
+        policy_loss = -torch.min(ratio * flat_advantages, clipped_ratio * flat_advantages).mean()
+
+        values = values.view_as(flat_returns)
+        value_loss = 0.5 * (flat_returns - values).pow(2).mean()
+        entropy = dist.entropy().mean()
+
+        loss = (
+            policy_loss
+            + self._config.value_loss_coef * value_loss
+            - self._config.entropy_coef * entropy
+        )
+
+        self._optimizer.zero_grad()
+        loss.backward()
+        nn.utils.clip_grad_norm_(self._model.parameters(), self._config.max_grad_norm)
+        self._optimizer.step()
+
+        self._step += 1
+        return AlgorithmUpdate(
+            step=self._step,
+            loss=float(loss.detach().cpu().item()),
+            policy_loss=float(policy_loss.detach().cpu().item()),
+            value_loss=float(value_loss.detach().cpu().item()),
+            entropy=float(entropy.detach().cpu().item()),
+        )
+
+    @property
+    def model(self) -> ActorCriticNetwork:
+        return self._model
+
+    @property
+    def optimizer(self) -> Adam:
+        return self._optimizer
+
+    def _ensure_advantages(self, batch: TransitionBatch) -> tuple[torch.Tensor, torch.Tensor]:
+        if batch.advantages is not None and batch.returns is not None:
+            return batch.advantages, batch.returns
+        advantages, returns = compute_gae(
+            rewards=batch.rewards,
+            values=batch.values,
+            dones=batch.dones,
+            gamma=self._config.gamma,
+            gae_lambda=self._config.gae_lambda,
+        )
+        batch.advantages = advantages
+        batch.returns = returns
+        return advantages, returns
+
+
+def _register() -> None:
+    register("ppo", lambda cfg, training: PPOLearner(cfg, training))
+
+
+_register()
+
+
+__all__ = ["PPOLearner"]

--- a/services/learner-py/learner/algo/registry.py
+++ b/services/learner-py/learner/algo/registry.py
@@ -1,0 +1,46 @@
+"""Registry for learner algorithms."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from torch import nn, optim
+
+from ..config import AlgorithmConfig, TrainingConfig
+from ..datamodel import AlgorithmUpdate, TransitionBatch
+
+
+class AlgorithmProtocol(Protocol):
+    """Interface implemented by learner algorithms."""
+
+    def update(self, batch: TransitionBatch) -> AlgorithmUpdate:
+        ...
+
+    @property
+    def model(self) -> nn.Module:
+        ...
+
+    @property
+    def optimizer(self) -> optim.Optimizer:
+        ...
+
+
+AlgorithmFactory = Callable[[AlgorithmConfig, TrainingConfig], AlgorithmProtocol]
+
+_REGISTRY: dict[str, AlgorithmFactory] = {}
+
+
+def register(name: str, factory: AlgorithmFactory) -> None:
+    _REGISTRY[name] = factory
+
+
+def get_algorithm(config: AlgorithmConfig, training: TrainingConfig) -> AlgorithmProtocol:
+    try:
+        factory = _REGISTRY[config.name]
+    except KeyError as exc:  # pragma: no cover - caller validated names already
+        raise ValueError(f"Unknown algorithm '{config.name}'") from exc
+    return factory(config, training)
+
+
+__all__ = ["AlgorithmFactory", "AlgorithmProtocol", "get_algorithm", "register"]

--- a/services/learner-py/learner/checkpoints.py
+++ b/services/learner-py/learner/checkpoints.py
@@ -1,0 +1,81 @@
+"""Checkpoint lifecycle management."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from safetensors.torch import save_file
+from torch import nn, optim
+
+from .config import CheckpointConfig
+
+
+@dataclass(slots=True)
+class CheckpointManifest:
+    step: int
+    path: Path
+    checksum: str
+    metadata: Mapping[str, Any]
+
+
+class CheckpointManager:
+    """Persists and manages learner checkpoints."""
+
+    def __init__(self, config: CheckpointConfig, *, base_path: Path | None = None) -> None:
+        self._config = config
+        self._base_path = base_path or Path(config.bucket)
+        self._base_path.mkdir(parents=True, exist_ok=True)
+        self._manifests: list[CheckpointManifest] = []
+        self._lock = asyncio.Lock()
+
+    async def save(
+        self,
+        *,
+        step: int,
+        model: nn.Module,
+        optimizer: optim.Optimizer,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CheckpointManifest:
+        metadata = {str(key): str(value) for key, value in (metadata or {}).items()}
+        checkpoint_dir = self._base_path / f"step_{step}"
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        tensors = {
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+        }
+        tensor_path = checkpoint_dir / "weights.safetensors"
+        await asyncio.get_running_loop().run_in_executor(
+            None, save_file, tensors, str(tensor_path), metadata
+        )
+        manifest_metadata = {**metadata, "optimizer": "adam", "artifact": tensor_path.name}
+        manifest = CheckpointManifest(
+            step=step,
+            path=tensor_path,
+            checksum="",  # TODO: implement checksums once wiring with object store is added
+            metadata=manifest_metadata,
+        )
+        manifest_path = checkpoint_dir / "MANIFEST.json"
+        manifest_path.write_text(json.dumps({"step": step, **manifest_metadata}, indent=2))
+
+        async with self._lock:
+            self._manifests.append(manifest)
+            self._manifests.sort(key=lambda item: item.step, reverse=True)
+            await self._trim_old_checkpoints()
+        return manifest
+
+    async def _trim_old_checkpoints(self) -> None:
+        while len(self._manifests) > self._config.keep_last:
+            manifest = self._manifests.pop()
+            shutil.rmtree(manifest.path.parent, ignore_errors=True)
+
+    @property
+    def latest(self) -> CheckpointManifest | None:
+        return self._manifests[0] if self._manifests else None
+
+
+__all__ = ["CheckpointManager", "CheckpointManifest"]

--- a/services/learner-py/learner/config.py
+++ b/services/learner-py/learner/config.py
@@ -1,0 +1,178 @@
+"""Configuration parsing and validation for the learner service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, MutableMapping
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+
+class ReplayConfig(BaseModel):
+    """Configuration for talking to the replay buffer service."""
+
+    endpoint: str = Field(..., description="Target gRPC endpoint for the replay service")
+    tls_enabled: bool = Field(False, description="Whether to use TLS when connecting to replay")
+    prefetch_depth: int = Field(4, ge=1, description="Number of batches to prefetch asynchronously")
+    batch_size: int = Field(..., gt=0, description="Total transitions per sample request")
+
+
+class AlgorithmConfig(BaseModel):
+    """Algorithm specific hyper-parameters. Defaults mirror PPO."""
+
+    name: str = Field("ppo", description="Learner algorithm identifier")
+    gamma: float = Field(0.99, ge=0.0, le=1.0)
+    gae_lambda: float = Field(0.95, ge=0.0, le=1.0)
+    clip_ratio: float = Field(0.2, ge=0.0, le=1.0)
+    entropy_coef: float = Field(0.01, ge=0.0)
+    value_loss_coef: float = Field(0.5, ge=0.0)
+    max_grad_norm: float = Field(0.5, ge=0.0)
+    num_epochs: int = Field(4, ge=1)
+    minibatch_size: int = Field(128, ge=1)
+
+class TrainingConfig(BaseModel):
+    """SGD control parameters."""
+
+    rollout_size: int = Field(1024, ge=1)
+    learning_rate: float = Field(3e-4, gt=0.0)
+    seed: int = Field(0, ge=0)
+    device: str = Field("cuda", description="PyTorch device string to execute on")
+    observation_dim: int = Field(..., gt=0)
+    action_dim: int = Field(..., gt=0)
+
+
+class CheckpointConfig(BaseModel):
+    """Durable artifact settings."""
+
+    bucket: str = Field(..., description="Object store bucket for checkpoints")
+    interval_steps: int = Field(10_000, ge=1)
+    keep_last: int = Field(3, ge=1)
+
+
+class WeightPublisherConfig(BaseModel):
+    """Settings for distributing policy weights to actors."""
+
+    backend: str = Field("redis", description="Distribution mechanism identifier")
+    endpoint: str = Field(..., description="Endpoint for the weight sink")
+    channel: str = Field(..., description="Channel/key used when publishing new weights")
+
+
+class ControlConfig(BaseModel):
+    orchestrator_endpoint: str = Field(..., description="HTTP endpoint for the orchestrator")
+    run_id: str = Field(..., description="Unique identifier for the active run")
+    heartbeat_interval_seconds: int = Field(30, ge=5)
+
+
+class LearnerConfig(BaseModel):
+    """Top level configuration model for the learner service."""
+
+    replay: ReplayConfig
+    training: TrainingConfig
+    algorithm: AlgorithmConfig = Field(default_factory=AlgorithmConfig)
+    checkpoints: CheckpointConfig
+    weights: WeightPublisherConfig
+    control: ControlConfig
+
+    @field_validator("algorithm")
+    @classmethod
+    def _validate_algo(cls, algo: AlgorithmConfig) -> AlgorithmConfig:
+        if algo.name.lower() != "ppo":
+            raise ValueError(
+                "Only the PPO algorithm is supported in the initial implementation; "
+                f"received '{algo.name}'."
+            )
+        return algo
+
+    @model_validator(mode="after")
+    def _validate_training_constraints(self) -> "LearnerConfig":
+        if self.algorithm.minibatch_size > self.training.rollout_size:
+            raise ValueError("minibatch_size cannot exceed rollout_size")
+        return self
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the learner entrypoint."""
+
+    parser = argparse.ArgumentParser(description="Run the Cartridge learner service")
+    parser.add_argument("--config", type=Path, help="Path to the learner configuration file", required=True)
+    parser.add_argument(
+        "--override",
+        type=str,
+        nargs="*",
+        default=[],
+        help="Override configuration values (dot.separated=value)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def load_config(path: Path, *, overrides: Iterable[str] | None = None) -> LearnerConfig:
+    """Load a :class:`LearnerConfig` from ``path`` applying optional overrides."""
+
+    raw = _read_config_file(path)
+    mutable = _ensure_mutable(raw)
+    for override in overrides or []:
+        _apply_override(mutable, override)
+    try:
+        return LearnerConfig.model_validate(mutable)
+    except ValidationError as exc:  # pragma: no cover - surfaced directly to caller
+        raise ValueError(f"Invalid learner configuration: {exc}") from exc
+
+
+def _read_config_file(path: Path) -> Mapping[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Configuration file '{path}' does not exist")
+    content = path.read_text()
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        data = yaml.safe_load(content)
+    else:
+        data = json.loads(content)
+    if not isinstance(data, Mapping):
+        raise ValueError("Configuration root must be a mapping")
+    return data
+
+
+def _ensure_mutable(data: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    return json.loads(json.dumps(data))
+
+
+def _apply_override(target: MutableMapping[str, Any], assignment: str) -> None:
+    if "=" not in assignment:
+        raise ValueError(f"Invalid override '{assignment}', expected key=value format")
+    key, raw_value = assignment.split("=", 1)
+    keys = key.split(".")
+    cursor: MutableMapping[str, Any] = target
+    for part in keys[:-1]:
+        node = cursor.setdefault(part, {})
+        if not isinstance(node, MutableMapping):
+            raise ValueError(f"Cannot override '{key}' because '{part}' is not a mapping")
+        cursor = node
+    cursor[keys[-1]] = _coerce_override_value(raw_value)
+
+
+def _coerce_override_value(raw: str) -> Any:
+    lowered = raw.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        try:
+            return float(raw)
+        except ValueError:
+            return raw
+
+
+__all__ = [
+    "AlgorithmConfig",
+    "CheckpointConfig",
+    "ControlConfig",
+    "LearnerConfig",
+    "ReplayConfig",
+    "TrainingConfig",
+    "WeightPublisherConfig",
+    "load_config",
+    "parse_args",
+]

--- a/services/learner-py/learner/control.py
+++ b/services/learner-py/learner/control.py
@@ -1,0 +1,47 @@
+"""Orchestrator control channel."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import aiohttp
+
+from .config import ControlConfig
+
+
+@dataclass(slots=True)
+class HeartbeatPayload:
+    step: int
+    policy_loss: float
+    value_loss: float
+    checkpoint_step: int | None
+
+
+class ControlClient:
+    """Thin wrapper around the orchestrator HTTP API."""
+
+    def __init__(self, config: ControlConfig) -> None:
+        self._config = config
+        self._session: aiohttp.ClientSession | None = None
+        self._lock = asyncio.Lock()
+
+    async def ensure_session(self) -> aiohttp.ClientSession:
+        async with self._lock:
+            if self._session is None:
+                self._session = aiohttp.ClientSession()
+            return self._session
+
+    async def send_heartbeat(self, payload: HeartbeatPayload) -> None:
+        session = await self.ensure_session()
+        url = f"{self._config.orchestrator_endpoint}/runs/{self._config.run_id}/heartbeat"
+        async with session.post(url, json=payload.__dict__, timeout=10):
+            pass
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+
+__all__ = ["ControlClient", "HeartbeatPayload"]

--- a/services/learner-py/learner/core.py
+++ b/services/learner-py/learner/core.py
@@ -1,0 +1,93 @@
+"""Main training loop for the learner."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Awaitable, Callable
+
+from .algo import get_algorithm
+from .config import LearnerConfig
+from .datamodel import AlgorithmUpdate, TransitionBatch
+from .metrics import MetricsRegistry
+from .replay_client import ReplayClient
+from .weights import WeightPayload, WeightPublisher
+from .checkpoints import CheckpointManager
+
+
+class LearnerCore:
+    """Coordinates the end-to-end training workflow."""
+
+    def __init__(
+        self,
+        config: LearnerConfig,
+        replay_client: ReplayClient,
+        checkpoints: CheckpointManager,
+        weights: WeightPublisher,
+        metrics: MetricsRegistry,
+        *,
+        heartbeat_callback: Callable[[AlgorithmUpdate], Awaitable[None]] | None = None,
+    ) -> None:
+        self._config = config
+        self._replay_client = replay_client
+        self._checkpoints = checkpoints
+        self._weights = weights
+        self._metrics = metrics
+        self._heartbeat_callback = heartbeat_callback
+        self._algorithm = get_algorithm(config.algorithm, config.training)
+        self._next_checkpoint_step = config.checkpoints.interval_steps
+        self._stopping = asyncio.Event()
+
+    async def run(self) -> None:
+        self._metrics.start_exporter()
+        async with self._replay_client:
+            while not self._stopping.is_set():
+                batch = await self._fetch_batch()
+                update = self._algorithm.update(batch)
+                self._record_update(update)
+                await self._maybe_checkpoint(update)
+                await self._maybe_publish_weights(update)
+                if self._heartbeat_callback is not None:
+                    await self._heartbeat_callback(update)
+
+    async def stop(self) -> None:
+        self._stopping.set()
+        await self._replay_client.stop()
+        await self._weights.close()
+
+    async def _fetch_batch(self) -> TransitionBatch:
+        async with self._metrics.track_sample_latency():
+            batch = await self._replay_client.sample()
+        self._metrics.samples_total.labels(status="ok").inc()
+        return batch
+
+    def _record_update(self, update: AlgorithmUpdate) -> None:
+        self._metrics.sgd_steps_total.inc()
+        self._metrics.policy_loss.set(update.policy_loss)
+        self._metrics.value_loss.set(update.value_loss)
+        self._metrics.entropy.set(update.entropy)
+
+    async def _maybe_checkpoint(self, update: AlgorithmUpdate) -> None:
+        if update.step < self._next_checkpoint_step:
+            return
+        start = time.perf_counter()
+        manifest = await self._checkpoints.save(
+            step=update.step,
+            model=self._algorithm.model,
+            optimizer=self._algorithm.optimizer,
+            metadata={"loss": update.loss},
+        )
+        duration = time.perf_counter() - start
+        self._metrics.checkpoint_duration.observe(duration)
+        self._next_checkpoint_step = update.step + self._config.checkpoints.interval_steps
+        await self._weights.publish(
+            WeightPayload(step=update.step, checksum=manifest.checksum, uri=str(manifest.path))
+        )
+        self._metrics.weights_published_total.inc()
+
+    async def _maybe_publish_weights(self, update: AlgorithmUpdate) -> None:
+        # Already handled inside checkpoint logic for the MVP cadence.
+        return
+
+
+__all__ = ["LearnerCore"]

--- a/services/learner-py/learner/datamodel.py
+++ b/services/learner-py/learner/datamodel.py
@@ -1,0 +1,52 @@
+"""Domain models used by the learner service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import torch
+
+
+@dataclass(slots=True)
+class TransitionBatch:
+    """A batch of transitions sampled from replay."""
+
+    observations: torch.Tensor
+    actions: torch.Tensor
+    log_probs: torch.Tensor
+    rewards: torch.Tensor
+    dones: torch.Tensor
+    values: torch.Tensor
+    advantages: torch.Tensor | None = None
+    returns: torch.Tensor | None = None
+    metadata: Mapping[str, str] | None = None
+
+    def to_device(self, device: torch.device | str) -> "TransitionBatch":
+        """Move all tensor fields to ``device`` returning ``self`` for chaining."""
+
+        self.observations = self.observations.to(device)
+        self.actions = self.actions.to(device)
+        self.log_probs = self.log_probs.to(device)
+        self.rewards = self.rewards.to(device)
+        self.dones = self.dones.to(device)
+        self.values = self.values.to(device)
+        if self.advantages is not None:
+            self.advantages = self.advantages.to(device)
+        if self.returns is not None:
+            self.returns = self.returns.to(device)
+        return self
+
+
+@dataclass(slots=True)
+class AlgorithmUpdate:
+    """Result of executing one optimisation step."""
+
+    step: int
+    loss: float
+    policy_loss: float
+    value_loss: float
+    entropy: float
+
+
+__all__ = ["AlgorithmUpdate", "TransitionBatch"]

--- a/services/learner-py/learner/main.py
+++ b/services/learner-py/learner/main.py
@@ -1,0 +1,79 @@
+"""Entrypoint wiring for the learner service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from .checkpoints import CheckpointManager
+from .datamodel import AlgorithmUpdate
+from .config import load_config, parse_args
+from .control import ControlClient, HeartbeatPayload
+from .core import LearnerCore
+from .metrics import MetricsRegistry
+from .replay_client import ReplayClient
+from .utils.logging import configure_logging
+from .weights import WeightPublisher
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _seed_everything(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():  # pragma: no cover - device specific
+        torch.cuda.manual_seed_all(seed)
+
+
+async def _run_async(config_path: Path, overrides: list[str]) -> None:
+    config = load_config(config_path, overrides=overrides)
+    configure_logging()
+    _LOGGER.info("learner.start", run_id=config.control.run_id)
+    _seed_everything(config.training.seed)
+
+    metrics = MetricsRegistry()
+    weights = WeightPublisher(config.weights)
+    checkpoints = CheckpointManager(config.checkpoints)
+    control = ControlClient(config.control)
+    replay = ReplayClient(config.replay)
+
+    async def heartbeat(update: AlgorithmUpdate) -> None:
+        checkpoint_step = checkpoints.latest.step if checkpoints.latest else None
+        payload = HeartbeatPayload(
+            step=update.step,
+            policy_loss=update.policy_loss,
+            value_loss=update.value_loss,
+            checkpoint_step=checkpoint_step,
+        )
+        await control.send_heartbeat(payload)
+
+    learner = LearnerCore(
+        config,
+        replay,
+        checkpoints,
+        weights,
+        metrics,
+        heartbeat_callback=heartbeat,
+    )
+    try:
+        await learner.run()
+    except asyncio.CancelledError:  # pragma: no cover - cancellation path
+        raise
+    finally:
+        await learner.stop()
+        await control.close()
+
+
+def run(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    asyncio.run(_run_async(args.config, args.override))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/services/learner-py/learner/metrics.py
+++ b/services/learner-py/learner/metrics.py
@@ -1,0 +1,48 @@
+"""Prometheus metrics and tracing utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import AsyncIterator
+
+from prometheus_client import Counter, Gauge, Histogram, start_http_server
+
+
+class MetricsRegistry:
+    """Centralised Prometheus metrics for the learner process."""
+
+    def __init__(self, *, port: int = 9001) -> None:
+        self._port = port
+        self.samples_total = Counter("learner_samples_total", "Number of samples processed", ["status"])
+        self.sample_latency_seconds = Histogram(
+            "learner_sample_latency_seconds", "Latency of replay sampling requests"
+        )
+        self.sgd_steps_total = Counter("learner_sgd_steps_total", "Number of SGD steps executed")
+        self.policy_loss = Gauge("learner_policy_loss", "Latest policy loss")
+        self.value_loss = Gauge("learner_value_loss", "Latest value loss")
+        self.entropy = Gauge("learner_entropy", "Latest policy entropy")
+        self.checkpoint_duration = Histogram(
+            "learner_checkpoint_duration_seconds", "Duration of checkpoint operations"
+        )
+        self.weights_published_total = Counter(
+            "learner_weights_publish_total", "Number of weight updates published"
+        )
+        self._server_task: asyncio.Task[None] | None = None
+
+    def start_exporter(self) -> None:
+        if self._server_task is None:
+            loop = asyncio.get_running_loop()
+            self._server_task = loop.create_task(self._run_exporter())
+
+    async def _run_exporter(self) -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, start_http_server, self._port)
+
+    @contextlib.asynccontextmanager
+    async def track_sample_latency(self) -> AsyncIterator[None]:
+        with self.sample_latency_seconds.time():
+            yield
+
+
+__all__ = ["MetricsRegistry"]

--- a/services/learner-py/learner/replay_client.py
+++ b/services/learner-py/learner/replay_client.py
@@ -1,0 +1,82 @@
+"""Async replay buffer client with background prefetching."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Awaitable, Callable
+
+from tenacity import AsyncRetrying, RetryError, stop_after_attempt, wait_random_exponential
+
+from .config import ReplayConfig
+from .datamodel import TransitionBatch
+
+SamplerFn = Callable[[], Awaitable[TransitionBatch]] | Callable[[], TransitionBatch]
+
+
+class ReplayClient:
+    """Client responsible for streaming batches from the replay buffer."""
+
+    def __init__(self, config: ReplayConfig, *, sampler: SamplerFn | None = None) -> None:
+        self._config = config
+        self._queue: asyncio.Queue[TransitionBatch] = asyncio.Queue(maxsize=config.prefetch_depth)
+        self._sampler = sampler
+        self._prefetch_task: asyncio.Task[None] | None = None
+        self._stopping = asyncio.Event()
+
+    async def __aenter__(self) -> "ReplayClient":
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.stop()
+
+    async def start(self) -> None:
+        if self._prefetch_task is None:
+            self._prefetch_task = asyncio.create_task(self._prefetch_loop())
+
+    async def stop(self) -> None:
+        if self._prefetch_task is not None:
+            self._stopping.set()
+            self._prefetch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._prefetch_task
+            self._prefetch_task = None
+            self._stopping.clear()
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:  # pragma: no cover - defensive
+                break
+
+    async def sample(self) -> TransitionBatch:
+        """Return the next available batch, waiting for prefetch if necessary."""
+
+        return await self._queue.get()
+
+    async def _prefetch_loop(self) -> None:
+        try:
+            async for attempt in AsyncRetrying(
+                wait=wait_random_exponential(multiplier=0.5, max=10.0),
+                stop=stop_after_attempt(5),
+                reraise=True,
+            ):
+                with attempt:
+                    while not self._stopping.is_set():
+                        batch = await self._invoke_sampler()
+                        await self._queue.put(batch)
+        except RetryError as exc:  # pragma: no cover - escalated to orchestrator later
+            raise RuntimeError("Replay client failed after retries") from exc
+
+    async def _invoke_sampler(self) -> TransitionBatch:
+        sampler = self._sampler or self._grpc_sampler
+        result = sampler()
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+
+    async def _grpc_sampler(self) -> TransitionBatch:
+        raise NotImplementedError("gRPC sampling will be implemented once protos are available")
+
+
+__all__ = ["ReplayClient", "SamplerFn"]

--- a/services/learner-py/learner/utils/logging.py
+++ b/services/learner-py/learner/utils/logging.py
@@ -1,0 +1,30 @@
+"""Logging configuration utilities."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import structlog
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure structlog and the standard logging module."""
+
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        stream=sys.stdout,
+    )
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.getLevelName(level)),
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+
+
+__all__ = ["configure_logging"]

--- a/services/learner-py/learner/utils/math.py
+++ b/services/learner-py/learner/utils/math.py
@@ -1,0 +1,50 @@
+"""Numerical helpers for reinforcement learning algorithms."""
+
+from __future__ import annotations
+
+import torch
+
+
+def compute_gae(
+    rewards: torch.Tensor,
+    values: torch.Tensor,
+    dones: torch.Tensor,
+    *,
+    gamma: float,
+    gae_lambda: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute Generalised Advantage Estimation.
+
+    Args:
+        rewards: Tensor of rewards with shape ``[T, B]``.
+        values: Value function predictions with shape ``[T + 1, B]``.
+        dones: Done flags with shape ``[T, B]``.
+        gamma: Discount factor.
+        gae_lambda: Smoothing parameter.
+
+    Returns:
+        advantages, returns tensors.
+    """
+
+    if rewards.ndim != 2 or values.ndim != 2 or dones.ndim != 2:
+        raise ValueError("GAE expects 2-D tensors (time, batch)")
+    if values.shape[0] != rewards.shape[0] + 1:
+        raise ValueError("Values must have one more timestep than rewards for bootstrapping")
+    if rewards.shape != dones.shape:
+        raise ValueError("Rewards and dones must have matching shapes")
+
+    device = rewards.device
+    advantages = torch.zeros_like(rewards, device=device)
+    gae = torch.zeros(rewards.shape[1], device=device)
+
+    for t in reversed(range(rewards.shape[0])):
+        mask = 1.0 - dones[t]
+        delta = rewards[t] + gamma * values[t + 1] * mask - values[t]
+        gae = delta + gamma * gae_lambda * mask * gae
+        advantages[t] = gae
+
+    returns = advantages + values[:-1]
+    return advantages, returns
+
+
+__all__ = ["compute_gae"]

--- a/services/learner-py/learner/weights.py
+++ b/services/learner-py/learner/weights.py
@@ -1,0 +1,61 @@
+"""Weight publication helpers."""
+
+"""Weight publication helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+from redis import asyncio as aioredis
+
+from .config import WeightPublisherConfig
+
+
+@dataclass(slots=True)
+class WeightPayload:
+    step: int
+    checksum: str
+    uri: str
+
+
+class WeightPublisher:
+    """Publishes weight updates to the configured distribution backend."""
+
+    def __init__(
+        self, config: WeightPublisherConfig, *, redis_client: aioredis.Redis | None = None
+    ) -> None:
+        self._config = config
+        self._redis: aioredis.Redis | None = redis_client
+        self._lock = asyncio.Lock()
+        self._last_payload: WeightPayload | None = None
+
+    async def publish(self, payload: WeightPayload) -> None:
+        async with self._lock:
+            if self._config.backend == "redis":
+                await self._publish_redis(payload)
+            else:  # pragma: no cover - not yet implemented
+                raise NotImplementedError(f"Unknown weight backend '{self._config.backend}'")
+            self._last_payload = payload
+
+    async def _publish_redis(self, payload: WeightPayload) -> None:
+        if self._redis is None:
+            self._redis = aioredis.from_url(self._config.endpoint)
+        message = json.dumps({"step": payload.step, "checksum": payload.checksum, "uri": payload.uri})
+        try:
+            await self._redis.publish(self._config.channel, message)
+        except Exception as exc:  # pragma: no cover - network failure path
+            raise RuntimeError("Failed to publish weights to redis") from exc
+
+    async def close(self) -> None:
+        if self._redis is not None:
+            await self._redis.close()
+            self._redis = None
+
+    @property
+    def last_payload(self) -> WeightPayload | None:
+        return self._last_payload
+
+
+__all__ = ["WeightPayload", "WeightPublisher"]

--- a/services/learner-py/pyproject.toml
+++ b/services/learner-py/pyproject.toml
@@ -1,0 +1,51 @@
+[tool.poetry]
+name = "cartridge-learner"
+version = "0.1.0"
+description = "Learner service for Cartridge reinforcement learning platform"
+authors = ["Cartridge Team <team@example.com>"]
+license = "Apache-2.0"
+readme = "README.md"
+packages = [{ include = "learner" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+torch = "^2.2.0"
+grpcio = "^1.60.0"
+pydantic = "^2.5.0"
+prometheus-client = "^0.19.0"
+aiohttp = "^3.8.0"
+tenacity = "^8.2.0"
+structlog = "^23.1.0"
+opentelemetry-api = "^1.19.0"
+opentelemetry-sdk = "^1.19.0"
+pyyaml = "^6.0.1"
+typing-extensions = "^4.9.0"
+numpy = "^1.26.0"
+safetensors = "^0.4.0"
+redis = "^5.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+pytest-asyncio = "^0.21.1"
+mypy = "^1.8.0"
+ruff = "^0.3.4"
+
+[tool.poetry.scripts]
+learner = "learner.main:run"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "B", "UP", "N", "ASYNC", "S"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+packages = ["learner"]

--- a/services/learner-py/tests/test_config.py
+++ b/services/learner-py/tests/test_config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from learner.config import load_config
+
+
+def test_load_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_payload = {
+        "replay": {"endpoint": "localhost:50051", "batch_size": 32},
+        "training": {
+            "rollout_size": 128,
+            "learning_rate": 0.0003,
+            "seed": 42,
+            "device": "cpu",
+            "observation_dim": 4,
+            "action_dim": 2,
+        },
+        "algorithm": {"name": "ppo"},
+        "checkpoints": {"bucket": str(tmp_path / "ckpts"), "interval_steps": 10, "keep_last": 2},
+        "weights": {"backend": "redis", "endpoint": "redis://localhost:6379", "channel": "weights"},
+        "control": {
+            "orchestrator_endpoint": "http://localhost:8000",
+            "run_id": "test-run",
+            "heartbeat_interval_seconds": 30,
+        },
+    }
+    config_path.write_text(json.dumps(config_payload))
+
+    config = load_config(config_path, overrides=["training.learning_rate=0.001"])
+
+    assert config.training.learning_rate == 0.001
+    assert config.training.observation_dim == 4
+    assert config.replay.prefetch_depth == 4

--- a/services/learner-py/tests/test_ppo.py
+++ b/services/learner-py/tests/test_ppo.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import torch
+
+from learner.algo.ppo import PPOLearner
+from learner.config import AlgorithmConfig, TrainingConfig
+from learner.datamodel import TransitionBatch
+
+
+def _make_training_config() -> TrainingConfig:
+    return TrainingConfig(
+        rollout_size=4,
+        learning_rate=1e-3,
+        seed=0,
+        device="cpu",
+        observation_dim=2,
+        action_dim=2,
+    )
+
+
+def test_ppo_update_runs() -> None:
+    algo = PPOLearner(AlgorithmConfig(), _make_training_config())
+    observations = torch.zeros(4, 2)
+    actions = torch.zeros(4, dtype=torch.long)
+    log_probs = torch.zeros(4)
+    rewards = torch.ones(4, 1)
+    dones = torch.zeros(4, 1)
+    values = torch.zeros(5, 1)
+
+    batch = TransitionBatch(
+        observations=observations,
+        actions=actions,
+        log_probs=log_probs,
+        rewards=rewards,
+        dones=dones,
+        values=values,
+    )
+
+    update = algo.update(batch)
+
+    assert update.step == 1
+    assert isinstance(update.loss, float)

--- a/services/learner-py/tests/test_utils_math.py
+++ b/services/learner-py/tests/test_utils_math.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import torch
+
+from learner.utils.math import compute_gae
+
+
+def test_compute_gae_shapes() -> None:
+    rewards = torch.tensor([[1.0, 0.0], [0.5, 0.2]])
+    values = torch.tensor([[0.1, 0.0], [0.2, 0.1], [0.0, 0.0]])
+    dones = torch.zeros_like(rewards)
+
+    advantages, returns = compute_gae(rewards, values, dones, gamma=0.99, gae_lambda=0.95)
+
+    assert advantages.shape == rewards.shape
+    assert returns.shape == rewards.shape
+    assert torch.all(torch.isfinite(advantages))


### PR DESCRIPTION
## Summary
- scaffold the Python-based learner service structure described in the design doc
- add configuration, replay client, PPO algorithm, checkpointing, weight publishing, and orchestration plumbing modules
- provide initial unit tests and Poetry project metadata for the learner package

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68de8fc4377083308be4f62a0a6acf44