### PR TITLE
Add unified local docker-compose stack

### DIFF
--- a/deployments/local/config/learner.yaml
+++ b/deployments/local/config/learner.yaml
@@ -1,0 +1,39 @@
+replay:
+  endpoint: replay:8080
+  tls_enabled: false
+  prefetch_depth: 4
+  batch_size: 64
+
+training:
+  rollout_size: 256
+  learning_rate: 0.0003
+  seed: 42
+  device: cpu
+  observation_dim: 29
+  action_dim: 9
+
+algorithm:
+  name: ppo
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_ratio: 0.2
+  entropy_coef: 0.01
+  value_loss_coef: 0.5
+  max_grad_norm: 0.5
+  num_epochs: 4
+  minibatch_size: 128
+
+checkpoints:
+  bucket: /checkpoints
+  interval_steps: 1000
+  keep_last: 3
+
+weights:
+  backend: redis
+  endpoint: redis://redis:6379/0
+  channel: learner_weights
+
+control:
+  orchestrator_endpoint: http://orchestrator:8080/api/v1
+  run_id: local-run
+  heartbeat_interval_seconds: 30

--- a/deployments/local/docker-compose.yml
+++ b/deployments/local/docker-compose.yml
@@ -1,0 +1,78 @@
+version: "3.9"
+
+services:
+  engine:
+    build:
+      context: ../..
+      dockerfile: services/engine-rust/Dockerfile
+    image: cartridge/engine-rust:local
+    environment:
+      ENGINE_SERVER_ADDR: 0.0.0.0:50051
+    ports:
+      - "50051:50051"
+
+  replay:
+    build:
+      context: ../../services/replay-go
+    image: cartridge/replay-go:local
+    command: ["replay-server", "-port", "8080", "-max-size", "200000"]
+    environment:
+      REPLAY_PORT: "8080"
+      REPLAY_MAX_SIZE: "200000"
+    ports:
+      - "8081:8080"
+
+  orchestrator:
+    build:
+      context: ../..
+      dockerfile: services/orchestrator-go/Dockerfile
+    image: cartridge/orchestrator-go:local
+    ports:
+      - "8080:8080"
+    depends_on:
+      - engine
+      - replay
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+  learner:
+    build:
+      context: ../..
+      dockerfile: services/learner-py/Dockerfile
+    image: cartridge/learner-py:local
+    command: ["--config", "/config/learner.yaml"]
+    volumes:
+      - learner-checkpoints:/checkpoints
+      - ./config/learner.yaml:/config/learner.yaml:ro
+    depends_on:
+      - replay
+      - orchestrator
+      - redis
+
+  actor:
+    build:
+      context: ../..
+      dockerfile: services/actor-rust/Dockerfile
+    image: cartridge/actor-rust:local
+    environment:
+      ACTOR_ENGINE_ADDR: http://engine:50051
+      ACTOR_REPLAY_ADDR: http://replay:8080
+      ACTOR_ACTOR_ID: actor-rust-1
+      ACTOR_ENV_ID: tictactoe
+      ACTOR_BATCH_SIZE: "64"
+      ACTOR_FLUSH_INTERVAL: "5"
+      ACTOR_LOG_LEVEL: info
+    depends_on:
+      - engine
+      - replay
+      - learner
+
+volumes:
+  learner-checkpoints:
+  redis-data:

--- a/services/actor-rust/Dockerfile
+++ b/services/actor-rust/Dockerfile
@@ -2,17 +2,16 @@
 FROM rust:1.70 as builder
 
 # Install protoc
-RUN apt-get update && apt-get install -y protobuf-compiler
+RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+WORKDIR /workspace
 
-# Copy manifests
-COPY Cargo.toml Cargo.lock ./
-
-# Copy source code
-COPY src/ src/
-COPY build.rs ./
+# Copy the repository structure needed for building the actor crate.
 COPY proto/ proto/
+COPY services/engine-rust/ services/engine-rust/
+COPY services/actor-rust/ services/actor-rust/
+
+WORKDIR /workspace/services/actor-rust
 
 # Build the application
 RUN cargo build --release
@@ -24,7 +23,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Copy the binary
-COPY --from=builder /app/target/release/actor /usr/local/bin/actor
+COPY --from=builder /workspace/services/actor-rust/target/release/actor /usr/local/bin/actor
 
 # Create non-root user
 RUN useradd -r -u 1000 actor

--- a/services/engine-rust/Dockerfile
+++ b/services/engine-rust/Dockerfile
@@ -2,18 +2,16 @@
 FROM rust:1.70 as builder
 
 # Install protoc
-RUN apt-get update && apt-get install -y protobuf-compiler
+RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+WORKDIR /workspace
 
-# Copy manifests
-COPY Cargo.toml Cargo.lock ./
+# Copy the repository structure needed for the workspace build.
+COPY proto/ proto/
+COPY services/actor-rust/ services/actor-rust/
+COPY services/engine-rust/ services/engine-rust/
 
-# Copy all crate directories
-COPY engine-core/ engine-core/
-COPY engine-server/ engine-server/
-COPY engine-proto/ engine-proto/
-COPY games-tictactoe/ games-tictactoe/
+WORKDIR /workspace/services/engine-rust
 
 # Build the application
 RUN cargo build --release --bin engine-server
@@ -25,7 +23,7 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Copy the binary
-COPY --from=builder /app/target/release/engine-server /usr/local/bin/engine-server
+COPY --from=builder /workspace/services/engine-rust/target/release/engine-server /usr/local/bin/engine-server
 
 # Create non-root user
 RUN useradd -r -u 1000 engine

--- a/services/learner-py/Dockerfile
+++ b/services/learner-py/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    POETRY_VERSION=1.7.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir "poetry==${POETRY_VERSION}"
+
+WORKDIR /workspace/services/learner-py
+
+COPY services/learner-py/pyproject.toml services/learner-py/poetry.lock ./
+
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi --only main
+
+COPY services/learner-py/ ./
+
+ENTRYPOINT ["poetry", "run", "learner"]

--- a/services/orchestrator-go/Dockerfile
+++ b/services/orchestrator-go/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.22 AS builder
+
+WORKDIR /workspace
+
+# Copy source code for the orchestrator module
+COPY services/orchestrator-go/ services/orchestrator-go/
+
+WORKDIR /workspace/services/orchestrator-go
+
+# Build the orchestrator binary
+RUN CGO_ENABLED=0 go build -o /workspace/bin/orchestrator ./cmd/server
+
+FROM gcr.io/distroless/base-debian12:nonroot
+
+COPY --from=builder /workspace/bin/orchestrator /usr/local/bin/orchestrator
+
+EXPOSE 8080
+
+USER nonroot
+
+ENTRYPOINT ["orchestrator"]

--- a/services/orchestrator-go/internal/events/nats.go
+++ b/services/orchestrator-go/internal/events/nats.go
@@ -1,3 +1,5 @@
+//go:build nats
+
 package events
 
 import (

--- a/services/orchestrator-go/internal/storage/postgres.go
+++ b/services/orchestrator-go/internal/storage/postgres.go
@@ -1,3 +1,5 @@
+//go:build postgres
+
 package storage
 
 import (
@@ -6,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	_ "github.com/lib/pq"
 	"github.com/cartridge/orchestrator/internal/types"
+	_ "github.com/lib/pq"
 )
 
 // PostgresStore implements RunStore backed by PostgreSQL


### PR DESCRIPTION
## Summary
- add a single docker-compose definition that launches the engine, replay, orchestrator, learner, actor, and redis services
- provide a sample learner configuration plus Dockerfiles for the learner and orchestrator images so the stack can build locally
- update Rust service Dockerfiles and gate optional Go dependencies behind build tags to allow building from the repo root

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b14e4f008330847d6d19c0537c61