### PR TITLE
Fix heartbeat test logger writer to avoid nil panic

### DIFF
--- a/services/orchestrator-go/internal/handlers/heartbeat_test.go
+++ b/services/orchestrator-go/internal/handlers/heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -43,8 +44,8 @@ func TestEnhancedHeartbeatHandler_HandleHeartbeat(t *testing.T) {
 
 	// Setup handler
 	publisher := events.NoopPublisher{}
-	logger := *zerolog.New(nil).Level(zerolog.Disabled)
-	handler := NewEnhancedHeartbeatHandler(store, publisher, logger)
+	logger := zerolog.New(io.Discard).Level(zerolog.Disabled)
+	handler := NewEnhancedHeartbeatHandler(store, publisher, *logger)
 
 	// Create request
 	requestBody := LearnerHeartbeatRequest{


### PR DESCRIPTION
## Summary
- construct the heartbeat handler test logger with io.Discard instead of a nil writer
- pass the dereferenced logger to the handler to match the constructor signature

## Testing
- go test ./internal/handlers -run TestEnhancedHeartbeatHandler_HandleHeartbeat -count=1


------
https://chatgpt.com/codex/tasks/task_e_6902749dcd2c833082f9131b768962fa