### PR TITLE
Address urgent TODOs in repository

### DIFF
--- a/services/orchestrator-go/internal/health/monitor.go
+++ b/services/orchestrator-go/internal/health/monitor.go
@@ -66,31 +66,31 @@ func (m *Monitor) Start(ctx context.Context) {
 }
 
 func (m *Monitor) checkStaleHeartbeats(ctx context.Context) {
-	// This would require adding a method to the service to list runs
-	// that need health checking. For now, we'll outline the logic:
-
 	now := time.Now()
 	staleThreshold := now.Add(-m.config.HeartbeatStaleAfter)
 	unresponsiveThreshold := now.Add(-m.config.HeartbeatUnresponsive)
 
-	// TODO: Add ListRunsForHealthCheck to service layer
-	// runs, err := m.orch.ListRunsForHealthCheck(ctx, types.RunStateRunning)
+	runs, err := m.orch.ListRunsForHealthCheck(ctx, types.RunStateRunning)
+	if err != nil {
+		m.logger.Error().Err(err).Msg("Failed to list runs for health check")
+		return
+	}
 
 	m.logger.Debug().
+		Int("run_count", len(runs)).
 		Time("stale_threshold", staleThreshold).
 		Time("unresponsive_threshold", unresponsiveThreshold).
 		Msg("Checking run health")
 
-	// Example logic for what this would do:
-	// for _, run := range runs {
-	//     if run.LastHeartbeatAt != nil {
-	//         if run.LastHeartbeatAt.Before(unresponsiveThreshold) && run.HealthStatus != types.RunHealthUnresponsive {
-	//             m.markUnresponsive(ctx, run)
-	//         } else if run.LastHeartbeatAt.Before(staleThreshold) && run.HealthStatus == types.RunHealthHealthy {
-	//             m.markStale(ctx, run)
-	//         }
-	//     }
-	// }
+	for _, run := range runs {
+		if run.LastHeartbeatAt != nil {
+			if run.LastHeartbeatAt.Before(unresponsiveThreshold) && run.HealthStatus != types.RunHealthUnresponsive {
+				m.markUnresponsive(ctx, run)
+			} else if run.LastHeartbeatAt.Before(staleThreshold) && run.HealthStatus == types.RunHealthHealthy {
+				m.markStale(ctx, run)
+			}
+		}
+	}
 }
 
 func (m *Monitor) markStale(ctx context.Context, run types.Run) {
@@ -105,16 +105,19 @@ func (m *Monitor) markStale(ctx context.Context, run types.Run) {
 	}
 
 	// Update run health status
-	run.HealthStatus = types.RunHealthHeartbeatStale
-	// Would need UpdateRunHealth method in service
+	updatedRun, err := m.orch.UpdateRunHealth(ctx, run.ID, types.RunHealthHeartbeatStale, "Heartbeat stale")
+	if err != nil {
+		m.logger.Error().Err(err).Str("run_id", run.ID).Msg("Failed to update run health status")
+		return
+	}
 
 	// Publish stale event
 	event := events.RunStatusEvent{
-		RunID:         run.ID,
-		State:         string(run.State),
-		RuntimeStatus: string(run.RuntimeStatus),
-		HealthStatus:  string(run.HealthStatus),
-		Step:          run.CurrentStep,
+		RunID:         updatedRun.ID,
+		State:         string(updatedRun.State),
+		RuntimeStatus: string(updatedRun.RuntimeStatus),
+		HealthStatus:  string(updatedRun.HealthStatus),
+		Step:          updatedRun.CurrentStep,
 		LastError:     "Heartbeat stale",
 	}
 
@@ -135,17 +138,21 @@ func (m *Monitor) markUnresponsive(ctx context.Context, run types.Run) {
 	}
 
 	// Update run health status
-	run.HealthStatus = types.RunHealthUnresponsive
-	// Would need UpdateRunHealth method in service
+	statusMsg := "Run unresponsive - no heartbeat for over 2 minutes"
+	updatedRun, err := m.orch.UpdateRunHealth(ctx, run.ID, types.RunHealthUnresponsive, statusMsg)
+	if err != nil {
+		m.logger.Error().Err(err).Str("run_id", run.ID).Msg("Failed to update run health status")
+		return
+	}
 
 	// Publish unresponsive event (triggers PagerDuty)
 	event := events.RunStatusEvent{
-		RunID:         run.ID,
-		State:         string(run.State),
-		RuntimeStatus: string(run.RuntimeStatus),
-		HealthStatus:  string(run.HealthStatus),
-		Step:          run.CurrentStep,
-		LastError:     "Run unresponsive - no heartbeat for over 2 minutes",
+		RunID:         updatedRun.ID,
+		State:         string(updatedRun.State),
+		RuntimeStatus: string(updatedRun.RuntimeStatus),
+		HealthStatus:  string(updatedRun.HealthStatus),
+		Step:          updatedRun.CurrentStep,
+		LastError:     statusMsg,
 	}
 
 	if err := m.publisher.PublishRunStatus(ctx, event); err != nil {

--- a/services/orchestrator-go/internal/service/orchestrator.go
+++ b/services/orchestrator-go/internal/service/orchestrator.go
@@ -105,6 +105,31 @@ func (o *Orchestrator) GetRun(ctx context.Context, runID string) (types.Run, err
 	return o.store.GetRun(ctx, runID)
 }
 
+// ListRunsForHealthCheck returns all runs that need health monitoring.
+func (o *Orchestrator) ListRunsForHealthCheck(ctx context.Context, state types.RunState) ([]types.Run, error) {
+	return o.store.ListRunsByState(ctx, state)
+}
+
+// UpdateRunHealth updates the health status of a run.
+func (o *Orchestrator) UpdateRunHealth(ctx context.Context, runID string, health types.RunHealth, statusMessage string) (types.Run, error) {
+	run, err := o.store.GetRun(ctx, runID)
+	if err != nil {
+		return types.Run{}, err
+	}
+
+	run.HealthStatus = health
+	if statusMessage != "" {
+		run.StatusMessage = statusMessage
+	}
+	run.UpdatedAt = o.now()
+
+	if err := o.store.UpdateRun(ctx, run); err != nil {
+		return types.Run{}, err
+	}
+
+	return run, nil
+}
+
 // ResetRun resets a run's progress to allow restarting from step 0.
 func (o *Orchestrator) ResetRun(ctx context.Context, runID string) (types.Run, error) {
 	run, err := o.store.GetRun(ctx, runID)

--- a/services/orchestrator-go/internal/service/orchestrator_test.go
+++ b/services/orchestrator-go/internal/service/orchestrator_test.go
@@ -20,6 +20,7 @@ type stubRunStore struct {
 	createRunFn          func(context.Context, types.Run) error
 	getRunFn             func(context.Context, string) (types.Run, error)
 	updateRunFn          func(context.Context, types.Run) error
+	listRunsByStateFn    func(context.Context, types.RunState) ([]types.Run, error)
 	appendTransitionFn   func(context.Context, storage.RunTransition) error
 	appendCommandFn      func(context.Context, types.RunCommand) error
 	getCommandFn         func(context.Context, string, string) (types.RunCommand, error)
@@ -46,6 +47,13 @@ func (s *stubRunStore) UpdateRun(ctx context.Context, run types.Run) error {
 		return s.updateRunFn(ctx, run)
 	}
 	return nil
+}
+
+func (s *stubRunStore) ListRunsByState(ctx context.Context, state types.RunState) ([]types.Run, error) {
+	if s.listRunsByStateFn != nil {
+		return s.listRunsByStateFn(ctx, state)
+	}
+	return []types.Run{}, nil
 }
 
 func (s *stubRunStore) AppendTransition(ctx context.Context, transition storage.RunTransition) error {

--- a/services/orchestrator-go/internal/storage/postgres.go
+++ b/services/orchestrator-go/internal/storage/postgres.go
@@ -109,6 +109,173 @@ func (p *PostgresStore) UpdateRun(ctx context.Context, run types.Run) error {
 	return nil
 }
 
+func (p *PostgresStore) ListRunsByState(ctx context.Context, state types.RunState) ([]types.Run, error) {
+	query := `
+		SELECT id, experiment_id, version_id, state, status_message, priority,
+			   launch_manifest, overrides, last_heartbeat_at, runtime_status,
+			   health_status, current_step, samples_per_sec, loss, checkpoint_version,
+			   started_at, ended_at, created_by, created_at, updated_at
+		FROM runs WHERE state = $1
+		ORDER BY created_at DESC`
+
+	rows, err := p.db.QueryContext(ctx, query, state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list runs by state: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []types.Run
+	for rows.Next() {
+		var run types.Run
+		var launchManifest, overrides []byte
+
+		err := rows.Scan(
+			&run.ID, &run.ExperimentID, &run.VersionID, &run.State, &run.StatusMessage,
+			&run.Priority, &launchManifest, &overrides, &run.LastHeartbeatAt,
+			&run.RuntimeStatus, &run.HealthStatus, &run.CurrentStep,
+			&run.SamplesPerSecond, &run.Loss, &run.CheckpointVersion,
+			&run.StartedAt, &run.EndedAt, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan run: %w", err)
+		}
+
+		run.LaunchManifest = json.RawMessage(launchManifest)
+		run.Overrides = json.RawMessage(overrides)
+		runs = append(runs, run)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating runs: %w", err)
+	}
+
+	return runs, nil
+}
+
+func (p *PostgresStore) AppendTransition(ctx context.Context, transition RunTransition) error {
+	query := `
+		INSERT INTO run_transitions (run_id, from_state, to_state, changed_by, reason, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`
+
+	_, err := p.db.ExecContext(ctx, query,
+		transition.RunID, transition.FromState, transition.ToState,
+		transition.ChangedBy, transition.Reason, transition.CreatedAt)
+
+	if err != nil {
+		return fmt.Errorf("failed to append transition: %w", err)
+	}
+
+	return nil
+}
+
+func (p *PostgresStore) AppendCommand(ctx context.Context, command types.RunCommand) error {
+	query := `
+		INSERT INTO run_commands (id, run_id, type, payload, actor_type, actor_id,
+								 issued_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+	_, err := p.db.ExecContext(ctx, query,
+		command.ID, command.RunID, command.Type, command.Payload,
+		command.Actor.Type, command.Actor.ID, command.IssuedAt, command.CreatedAt)
+
+	if err != nil {
+		if isUniqueViolation(err) {
+			return ErrConflict
+		}
+		return fmt.Errorf("failed to append command: %w", err)
+	}
+
+	return nil
+}
+
+func (p *PostgresStore) GetCommand(ctx context.Context, runID, commandID string) (types.RunCommand, error) {
+	query := `
+		SELECT id, run_id, type, payload, actor_type, actor_id, issued_at,
+			   delivered_at, acknowledged_at, created_at
+		FROM run_commands WHERE run_id = $1 AND id = $2`
+
+	var cmd types.RunCommand
+	var actorType, actorID string
+	var payload []byte
+
+	err := p.db.QueryRowContext(ctx, query, runID, commandID).Scan(
+		&cmd.ID, &cmd.RunID, &cmd.Type, &payload, &actorType, &actorID,
+		&cmd.IssuedAt, &cmd.DeliveredAt, &cmd.AcknowledgedAt, &cmd.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return types.RunCommand{}, ErrNotFound
+	}
+	if err != nil {
+		return types.RunCommand{}, fmt.Errorf("failed to get command: %w", err)
+	}
+
+	cmd.Payload = json.RawMessage(payload)
+	cmd.Actor = types.CommandActor{
+		Type: types.CommandActorType(actorType),
+		ID:   actorID,
+	}
+
+	return cmd, nil
+}
+
+func (p *PostgresStore) NextPendingCommand(ctx context.Context, runID string) (types.RunCommand, error) {
+	query := `
+		SELECT id, run_id, type, payload, actor_type, actor_id, issued_at,
+			   delivered_at, acknowledged_at, created_at
+		FROM run_commands
+		WHERE run_id = $1 AND delivered_at IS NULL
+		ORDER BY issued_at ASC
+		LIMIT 1`
+
+	var cmd types.RunCommand
+	var actorType, actorID string
+	var payload []byte
+
+	err := p.db.QueryRowContext(ctx, query, runID).Scan(
+		&cmd.ID, &cmd.RunID, &cmd.Type, &payload, &actorType, &actorID,
+		&cmd.IssuedAt, &cmd.DeliveredAt, &cmd.AcknowledgedAt, &cmd.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return types.RunCommand{}, ErrNoCommands
+	}
+	if err != nil {
+		return types.RunCommand{}, fmt.Errorf("failed to get next pending command: %w", err)
+	}
+
+	cmd.Payload = json.RawMessage(payload)
+	cmd.Actor = types.CommandActor{
+		Type: types.CommandActorType(actorType),
+		ID:   actorID,
+	}
+
+	return cmd, nil
+}
+
+func (p *PostgresStore) SaveCommand(ctx context.Context, command types.RunCommand) error {
+	query := `
+		UPDATE run_commands SET
+			delivered_at = $3, acknowledged_at = $4
+		WHERE run_id = $1 AND id = $2`
+
+	result, err := p.db.ExecContext(ctx, query,
+		command.RunID, command.ID, command.DeliveredAt, command.AcknowledgedAt)
+
+	if err != nil {
+		return fmt.Errorf("failed to save command: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
 // Helper function to check for PostgreSQL unique constraint violations
 func isUniqueViolation(err error) bool {
 	// This would check the PostgreSQL error code for unique constraint violations

--- a/services/orchestrator-go/internal/storage/storage.go
+++ b/services/orchestrator-go/internal/storage/storage.go
@@ -24,6 +24,7 @@ type RunStore interface {
 	CreateRun(ctx context.Context, run types.Run) error
 	GetRun(ctx context.Context, id string) (types.Run, error)
 	UpdateRun(ctx context.Context, run types.Run) error
+	ListRunsByState(ctx context.Context, state types.RunState) ([]types.Run, error)
 	AppendTransition(ctx context.Context, transition RunTransition) error
 	AppendCommand(ctx context.Context, command types.RunCommand) error
 	GetCommand(ctx context.Context, runID, commandID string) (types.RunCommand, error)
@@ -89,6 +90,19 @@ func (m *MemoryStore) UpdateRun(_ context.Context, run types.Run) error {
 	}
 	m.runs[run.ID] = run
 	return nil
+}
+
+// ListRunsByState returns all runs matching the specified state.
+func (m *MemoryStore) ListRunsByState(_ context.Context, state types.RunState) ([]types.Run, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var runs []types.Run
+	for _, run := range m.runs {
+		if run.State == state {
+			runs = append(runs, run)
+		}
+	}
+	return runs, nil
 }
 
 // AppendTransition adds a state transition entry.


### PR DESCRIPTION
This commit addresses the urgent TODO in the health monitor by implementing the missing service layer methods and storage functionality:

- Added ListRunsByState method to RunStore interface for querying runs by state
- Implemented ListRunsForHealthCheck in Orchestrator service for health monitoring
- Added UpdateRunHealth method to persist health status changes
- Updated health monitor to actively check and mark stale/unresponsive runs
- Completed missing PostgresStore methods (transitions, commands)
- Updated test stubs to support new interface methods

The health monitor can now:
- Query all running runs periodically
- Detect stale heartbeats (configurable threshold)
- Detect unresponsive runs (configurable threshold)
- Update run health status in storage
- Publish health status events for alerting

All tests pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)