### PR TITLE
Fix orchestrator status initialization and reset events

### DIFF
--- a/services/orchestrator-go/internal/service/orchestrator.go
+++ b/services/orchestrator-go/internal/service/orchestrator.go
@@ -68,7 +68,7 @@ func (o *Orchestrator) CreateRun(ctx context.Context, input CreateRunInput) (typ
 		LaunchManifest:   input.LaunchManifest,
 		Overrides:        input.Overrides,
 		Priority:         input.Priority,
-		RuntimeStatus:    types.RuntimeStatusRunning,
+		RuntimeStatus:    types.RuntimeStatusPaused, // Start paused until first heartbeat
 		HealthStatus:     types.RunHealthHealthy,
 		CurrentStep:      0,
 		SamplesPerSecond: 0,
@@ -175,12 +175,26 @@ func (o *Orchestrator) ResetRun(ctx context.Context, runID string) (types.Run, e
 	run.Loss = 0
 	run.SamplesPerSecond = 0
 	run.LastHeartbeatAt = nil
-	run.RuntimeStatus = types.RuntimeStatusRunning
+	run.RuntimeStatus = types.RuntimeStatusPaused // Reset to paused until learner comes back
 	run.HealthStatus = types.RunHealthHealthy
 	run.UpdatedAt = o.now()
 
 	if err := o.store.UpdateRun(ctx, run); err != nil {
 		return types.Run{}, err
+	}
+
+	// Publish status event so dashboards are aware of the reset
+	event := events.RunStatusEvent{
+		RunID:            run.ID,
+		State:            string(run.State),
+		RuntimeStatus:    string(run.RuntimeStatus),
+		HealthStatus:     string(run.HealthStatus),
+		Step:             run.CurrentStep,
+		SamplesPerSecond: run.SamplesPerSecond,
+		Loss:             run.Loss,
+	}
+	if err := o.events.PublishRunStatus(ctx, event); err != nil {
+		o.logger.Error().Err(err).Str("run_id", run.ID).Msg("failed to publish run status event after reset")
 	}
 
 	o.logger.Info().Str("run_id", runID).Msg("run progress reset successfully")

--- a/services/orchestrator-go/internal/service/orchestrator_test.go
+++ b/services/orchestrator-go/internal/service/orchestrator_test.go
@@ -505,3 +505,74 @@ func TestUpdateRunHealthPersistsChanges(t *testing.T) {
 		t.Fatalf("expected updated run to reflect new health status")
 	}
 }
+
+func TestResetRunClearsProgressAndPublishesEvent(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	lastHB := now.Add(-time.Hour)
+	stored := types.Run{
+		ID:                "run-1",
+		State:             types.RunStateRunning,
+		CurrentStep:       100,
+		CheckpointVersion: 5,
+		Loss:              0.42,
+		SamplesPerSecond:  256.7,
+		RuntimeStatus:     types.RuntimeStatusRunning,
+		HealthStatus:      types.RunHealthHealthy,
+		LastHeartbeatAt:   &lastHB,
+	}
+	var saved types.Run
+	publisher := &stubPublisher{}
+	store := &stubRunStore{
+		getRunFn: func(ctx context.Context, id string) (types.Run, error) {
+			return stored, nil
+		},
+		updateRunFn: func(ctx context.Context, run types.Run) error {
+			saved = run
+			return nil
+		},
+	}
+
+	orch := NewOrchestrator(store, publisher, newTestLogger())
+	orch.WithNow(func() time.Time { return now })
+
+	reset, err := orch.ResetRun(context.Background(), stored.ID)
+	if err != nil {
+		t.Fatalf("ResetRun returned error: %v", err)
+	}
+
+	if saved.CurrentStep != 0 {
+		t.Fatalf("expected step to be reset to 0, got %d", saved.CurrentStep)
+	}
+	if saved.CheckpointVersion != 0 {
+		t.Fatalf("expected checkpoint version to be reset to 0, got %d", saved.CheckpointVersion)
+	}
+	if saved.Loss != 0 {
+		t.Fatalf("expected loss to be reset to 0, got %f", saved.Loss)
+	}
+	if saved.SamplesPerSecond != 0 {
+		t.Fatalf("expected samples per second to be reset to 0, got %f", saved.SamplesPerSecond)
+	}
+	if saved.LastHeartbeatAt != nil {
+		t.Fatalf("expected last heartbeat to be nil, got %v", saved.LastHeartbeatAt)
+	}
+	if saved.RuntimeStatus != types.RuntimeStatusPaused {
+		t.Fatalf("expected runtime status to be paused, got %s", saved.RuntimeStatus)
+	}
+	if saved.HealthStatus != types.RunHealthHealthy {
+		t.Fatalf("expected health status to remain healthy, got %s", saved.HealthStatus)
+	}
+	if saved.UpdatedAt != now {
+		t.Fatalf("expected updated timestamp to be set to now")
+	}
+	if reset.CurrentStep != 0 || reset.RuntimeStatus != types.RuntimeStatusPaused {
+		t.Fatalf("expected returned run to reflect reset state")
+	}
+
+	if len(publisher.runStatusEvents) != 1 {
+		t.Fatalf("expected status event to be published after reset")
+	}
+	event := publisher.runStatusEvents[0]
+	if event.RunID != stored.ID || event.Step != 0 || event.RuntimeStatus != string(types.RuntimeStatusPaused) {
+		t.Fatalf("unexpected status event: %#v", event)
+	}
+}


### PR DESCRIPTION
- Fresh runs now start with RuntimeStatusPaused instead of RuntimeStatusRunning until the first heartbeat is received from the learner
- ResetRun now publishes status events so dashboards are aware of the reset
- ResetRun also sets RuntimeStatus to Paused (consistent with fresh runs)
- Added comprehensive test for ResetRun to verify event publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)