### PR TITLE
Fix GLIBC version compatibility in Docker container

### DIFF
--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -33,7 +33,7 @@ RUN if [ "$BUILD_HEALTHCHECK" = "true" ]; then \
 RUN printf '#!/bin/sh\nexec /usr/local/bin/%s "$@"\n' "${BINARY_NAME}" > /workspace/bin/entrypoint.sh && \
     chmod +x /workspace/bin/entrypoint.sh
 
-FROM busybox:1.36 AS busybox
+FROM alpine:3.19 AS busybox
 
 FROM gcr.io/distroless/base-debian12:nonroot
 


### PR DESCRIPTION
Changed busybox source from busybox:1.36 to alpine:3.19 to resolve GLIBC_2.38 compatibility error. Alpine's busybox is statically linked with musl libc and has no GLIBC dependencies, making it compatible with the distroless/base-debian12 base image which uses GLIBC 2.36.

This fixes the weights service healthcheck errors: "/busybox/busybox: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)