### PR TITLE
Fix busybox runtime for Go service distroless images

### DIFF
--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -41,6 +41,8 @@ ARG BINARY_NAME
 ARG BUILD_HEALTHCHECK
 
 COPY --from=busybox /bin/busybox /busybox/busybox
+COPY --from=busybox /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=busybox /lib/libc.musl-x86_64.so.1 /lib/libc.musl-x86_64.so.1
 
 # Copy all binaries (includes main binary and optional healthcheck)
 COPY --from=builder /workspace/bin/${BINARY_NAME}* /usr/local/bin/


### PR DESCRIPTION
## Summary
- copy the musl dynamic loader and libc from the busybox build stage
- ensure busybox can execute inside the distroless Go service images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69036c3dd2408330abce8cf9bec418e2