### PR TITLE
refactor: update metrics macro usage

### DIFF
--- a/services/actor-rust/src/actor.rs
+++ b/services/actor-rust/src/actor.rs
@@ -64,7 +64,10 @@ impl Actor {
                             service_clone, addr_clone, attempt
                         );
                     } else {
-                        info!("Successfully connected to {} at {}", service_clone, addr_clone);
+                        info!(
+                            "Successfully connected to {} at {}",
+                            service_clone, addr_clone
+                        );
                     }
                     Ok(channel)
                 }
@@ -167,20 +170,12 @@ impl Actor {
 
     pub async fn new(config: Config) -> Result<Self> {
         // Connect to engine service with retry
-        let engine_channel = Self::connect_with_retry(
-            &config.engine_addr,
-            "engine",
-            &config,
-        )
-        .await?;
+        let engine_channel =
+            Self::connect_with_retry(&config.engine_addr, "engine", &config).await?;
 
         // Connect to replay service with retry
-        let replay_channel = Self::connect_with_retry(
-            &config.replay_addr,
-            "replay",
-            &config,
-        )
-        .await?;
+        let replay_channel =
+            Self::connect_with_retry(&config.replay_addr, "replay", &config).await?;
 
         let mut engine_client = EngineClient::new(engine_channel);
         let replay_client = ReplayClient::new(replay_channel);
@@ -235,9 +230,9 @@ impl Actor {
 
         gauge!(
             "actor_transitions_buffered",
-            0.0,
             "env_id" => self.config.env_id.clone()
-        );
+        )
+        .set(0.0);
 
         info!("Entering main event loop");
 
@@ -282,26 +277,26 @@ impl Actor {
                             let duration = episode_start.elapsed().as_secs_f64();
                             counter!(
                                 "actor_episode_results_total",
-                                1,
                                 "result" => "success",
                                 "env_id" => env_label.clone()
-                            );
+                            )
+                            .increment(1);
                             histogram!(
                                 "actor_episode_duration_seconds",
-                                duration,
                                 "result" => "success",
                                 "env_id" => env_label.clone()
-                            );
+                            )
+                            .record(duration);
                             gauge!(
                                 "actor_episode_last_steps",
-                                steps as f64,
                                 "env_id" => env_label.clone()
-                            );
+                            )
+                            .set(steps as f64);
                             gauge!(
                                 "actor_episode_last_return",
-                                total_reward as f64,
                                 "env_id" => env_label.clone()
-                            );
+                            )
+                            .set(total_reward as f64);
                             debug!(
                                 episode = new_count,
                                 steps,
@@ -319,16 +314,16 @@ impl Actor {
                             let duration = episode_start.elapsed().as_secs_f64();
                             counter!(
                                 "actor_episode_results_total",
-                                1,
                                 "result" => "error",
                                 "env_id" => env_label
-                            );
+                            )
+                            .increment(1);
                             histogram!(
                                 "actor_episode_duration_seconds",
-                                duration,
                                 "result" => "error",
                                 "env_id" => self.config.env_id.clone()
-                            );
+                            )
+                            .record(duration);
                             // Continue with next episode rather than stopping
                         }
                     }
@@ -459,9 +454,9 @@ impl Actor {
 
                 gauge!(
                     "actor_transitions_buffered",
-                    buffer.len() as f64,
                     "env_id" => self.config.env_id.clone()
-                );
+                )
+                .set(buffer.len() as f64);
 
                 buffer.len() >= self.config.batch_size
             }; // buffer guard dropped here
@@ -497,9 +492,9 @@ impl Actor {
             if buffer.is_empty() {
                 gauge!(
                     "actor_transitions_buffered",
-                    0.0,
                     "env_id" => self.config.env_id.clone()
-                );
+                )
+                .set(0.0);
                 return Ok(());
             }
             std::mem::take(&mut *buffer)
@@ -539,38 +534,38 @@ impl Actor {
                 }
                 counter!(
                     "actor_flush_results_total",
-                    1,
                     "result" => "success",
                     "env_id" => env_label.clone()
-                );
+                )
+                .increment(1);
                 counter!(
                     "actor_transitions_flushed_total",
-                    count as u64,
                     "env_id" => env_label.clone()
-                );
+                )
+                .increment(count as u64);
                 gauge!(
                     "actor_transitions_buffered",
-                    0.0,
                     "env_id" => env_label
-                );
+                )
+                .set(0.0);
                 Ok(())
             }
             Err(e) => {
                 counter!(
                     "actor_flush_results_total",
-                    1,
                     "result" => "error",
                     "env_id" => self.config.env_id.clone()
-                );
+                )
+                .increment(1);
                 let mut buffer = self.transition_buffer.lock().unwrap();
                 buffer.splice(0..0, transitions.into_iter());
                 let buffer_len = buffer.len();
                 drop(buffer);
                 gauge!(
                     "actor_transitions_buffered",
-                    buffer_len as f64,
                     "env_id" => self.config.env_id.clone()
-                );
+                )
+                .set(buffer_len as f64);
                 error!(
                     error = %e,
                     transitions = count,
@@ -649,11 +644,7 @@ mod tests {
     #[tonic::async_trait]
     impl Engine for MockEngine {
         type BatchSimulateStream = std::pin::Pin<
-            Box<
-                dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>>
-                    + Send
-                    + 'static,
-            >,
+            Box<dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>> + Send + 'static>,
         >;
 
         async fn get_capabilities(
@@ -719,11 +710,7 @@ mod tests {
     #[tonic::async_trait]
     impl Engine for FailingEngine {
         type BatchSimulateStream = std::pin::Pin<
-            Box<
-                dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>>
-                    + Send
-                    + 'static,
-            >,
+            Box<dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>> + Send + 'static>,
         >;
 
         async fn get_capabilities(
@@ -805,11 +792,7 @@ mod tests {
     #[tonic::async_trait]
     impl Engine for SlowEngine {
         type BatchSimulateStream = std::pin::Pin<
-            Box<
-                dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>>
-                    + Send
-                    + 'static,
-            >,
+            Box<dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>> + Send + 'static>,
         >;
 
         async fn get_capabilities(
@@ -878,11 +861,7 @@ mod tests {
     #[tonic::async_trait]
     impl Engine for SlowStepEngine {
         type BatchSimulateStream = std::pin::Pin<
-            Box<
-                dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>>
-                    + Send
-                    + 'static,
-            >,
+            Box<dyn tokio_stream::Stream<Item = Result<SimResultChunk, Status>> + Send + 'static>,
         >;
 
         async fn get_capabilities(
@@ -1353,7 +1332,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let config = create_test_config(engine_addr.clone(), replay_addr.clone());
         let actor = Actor::new(config).await.expect("failed to create actor");
@@ -1384,7 +1364,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let config = create_test_config(engine_addr, replay_addr);
         let actor = Actor::new(config).await.expect("failed to create actor");
@@ -1418,7 +1399,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.max_episodes = 3;
@@ -1433,7 +1415,10 @@ mod tests {
         };
 
         // Wait for completion
-        actor_handle.await.unwrap().expect("actor run should succeed");
+        actor_handle
+            .await
+            .unwrap()
+            .expect("actor run should succeed");
 
         // Verify episode count
         assert_eq!(
@@ -1470,7 +1455,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.max_episodes = 1;
@@ -1482,15 +1468,14 @@ mod tests {
             tokio::spawn(async move { actor.run().await })
         };
 
-        actor_handle.await.unwrap().expect("actor run should succeed");
+        actor_handle
+            .await
+            .unwrap()
+            .expect("actor run should succeed");
 
         // Verify all transitions were stored
         let stored = stored_transitions.lock().unwrap();
-        assert_eq!(
-            stored.len(),
-            10,
-            "all 10 transitions should be flushed"
-        );
+        assert_eq!(stored.len(), 10, "all 10 transitions should be flushed");
 
         engine_shutdown.send(()).unwrap();
         replay_shutdown.send(()).unwrap();
@@ -1511,7 +1496,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let config = create_test_config(engine_addr, replay_addr);
         let actor = Actor::new(config).await.expect("failed to create actor");
@@ -1534,7 +1520,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let config = create_test_config(engine_addr, replay_addr);
         let actor = Actor::new(config).await.expect("failed to create actor");
@@ -1557,7 +1544,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let config = create_test_config(engine_addr, replay_addr);
         let actor = Actor::new(config).await.expect("failed to create actor");
@@ -1602,7 +1590,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.max_episodes = 2;
@@ -1613,7 +1602,10 @@ mod tests {
             tokio::spawn(async move { actor.run().await })
         };
 
-        actor_handle.await.unwrap().expect("actor should complete successfully");
+        actor_handle
+            .await
+            .unwrap()
+            .expect("actor should complete successfully");
 
         assert_eq!(
             actor.episode_count.load(Ordering::Relaxed),
@@ -1635,7 +1627,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.episode_timeout_secs = 1; // Very short timeout
@@ -1662,7 +1655,8 @@ mod tests {
         let engine = SlowStepEngine;
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.episode_timeout_secs = 1; // Very short timeout
@@ -1696,7 +1690,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.max_episodes = 100; // Large number
@@ -1745,7 +1740,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.max_episodes = 3;
@@ -1778,7 +1774,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let mut config = create_test_config(engine_addr, replay_addr);
         config.max_episodes = 1;
@@ -1790,7 +1787,10 @@ mod tests {
         assert_eq!(steps, 5);
 
         // Force final flush
-        actor.flush_buffer().await.expect("final flush should succeed");
+        actor
+            .flush_buffer()
+            .await
+            .expect("final flush should succeed");
 
         // Verify buffer is empty
         assert_eq!(
@@ -1823,7 +1823,8 @@ mod tests {
         };
 
         let (engine_addr, engine_shutdown, engine_handle) = start_mock_engine_server(engine).await;
-        let (replay_addr, replay_shutdown, replay_handle) = start_mock_replay_server(replay_service).await;
+        let (replay_addr, replay_shutdown, replay_handle) =
+            start_mock_replay_server(replay_service).await;
 
         let config = create_test_config(engine_addr, replay_addr);
         let actor = Actor::new(config).await.expect("failed to create actor");

--- a/services/engine-rust/engine-core/src/registry.rs
+++ b/services/engine-rust/engine-core/src/registry.rs
@@ -112,7 +112,7 @@ pub fn register_game(env_id: String, factory: GameFactory) {
     if registry.contains_key(&env_id) {
         warn!(env_id = %env_id, "Overriding existing game registration");
     }
-    counter!("engine_registry_registrations_total");
+    counter!("engine_registry_registrations_total").increment(1);
     registry.insert(env_id, factory);
     gauge!("engine_registry_games").set(registry.len() as f64);
 }
@@ -147,7 +147,7 @@ pub fn create_game(env_id: &str) -> Option<Box<dyn ErasedGame>> {
         Some(factory) => Some(factory()),
         None => {
             warn!(env_id = %env_id, "Attempted to create unregistered game");
-            counter!("engine_registry_create_failures_total");
+            counter!("engine_registry_create_failures_total").increment(1);
             None
         }
     }

--- a/services/engine-rust/engine-server/src/buffers.rs
+++ b/services/engine-rust/engine-server/src/buffers.rs
@@ -87,12 +87,8 @@ impl BufferPool {
     pub fn get_state_buffer(&self) -> Vec<u8> {
         let mut buffers = self.state_buffers.lock().unwrap();
         let buffer = buffers.pop().unwrap_or_else(Vec::new);
-        counter!("engine_buffer_pool_borrows_total", 1, "buffer" => "state");
-        gauge!(
-            "engine_buffer_pool_available",
-            buffers.len() as f64,
-            "buffer" => "state"
-        );
+        counter!("engine_buffer_pool_borrows_total", "buffer" => "state").increment(1);
+        gauge!("engine_buffer_pool_available", "buffer" => "state").set(buffers.len() as f64);
         buffer
     }
 
@@ -106,29 +102,21 @@ impl BufferPool {
         // Shrink oversized buffers to prevent memory leaks from large allocations
         if buf.capacity() > MAX_BUFFER_CAPACITY {
             buf.shrink_to(MAX_BUFFER_CAPACITY);
-            counter!("engine_buffer_pool_shrinks_total", 1, "buffer" => "state");
+            counter!("engine_buffer_pool_shrinks_total", "buffer" => "state").increment(1);
         }
 
         let mut buffers = self.state_buffers.lock().unwrap();
         buffers.push(buf);
-        counter!("engine_buffer_pool_returns_total", 1, "buffer" => "state");
-        gauge!(
-            "engine_buffer_pool_available",
-            buffers.len() as f64,
-            "buffer" => "state"
-        );
+        counter!("engine_buffer_pool_returns_total", "buffer" => "state").increment(1);
+        gauge!("engine_buffer_pool_available", "buffer" => "state").set(buffers.len() as f64);
     }
 
     /// Get an observation buffer from the pool
     pub fn get_obs_buffer(&self) -> Vec<u8> {
         let mut buffers = self.obs_buffers.lock().unwrap();
         let buffer = buffers.pop().unwrap_or_else(Vec::new);
-        counter!("engine_buffer_pool_borrows_total", 1, "buffer" => "obs");
-        gauge!(
-            "engine_buffer_pool_available",
-            buffers.len() as f64,
-            "buffer" => "obs"
-        );
+        counter!("engine_buffer_pool_borrows_total", "buffer" => "obs").increment(1);
+        gauge!("engine_buffer_pool_available", "buffer" => "obs").set(buffers.len() as f64);
         buffer
     }
 
@@ -142,29 +130,21 @@ impl BufferPool {
         // Shrink oversized buffers to prevent memory leaks from large allocations
         if buf.capacity() > MAX_BUFFER_CAPACITY {
             buf.shrink_to(MAX_BUFFER_CAPACITY);
-            counter!("engine_buffer_pool_shrinks_total", 1, "buffer" => "obs");
+            counter!("engine_buffer_pool_shrinks_total", "buffer" => "obs").increment(1);
         }
 
         let mut buffers = self.obs_buffers.lock().unwrap();
         buffers.push(buf);
-        counter!("engine_buffer_pool_returns_total", 1, "buffer" => "obs");
-        gauge!(
-            "engine_buffer_pool_available",
-            buffers.len() as f64,
-            "buffer" => "obs"
-        );
+        counter!("engine_buffer_pool_returns_total", "buffer" => "obs").increment(1);
+        gauge!("engine_buffer_pool_available", "buffer" => "obs").set(buffers.len() as f64);
     }
 
     /// Get an action buffer from the pool
     pub fn get_action_buffer(&self) -> Vec<u8> {
         let mut buffers = self.action_buffers.lock().unwrap();
         let buffer = buffers.pop().unwrap_or_else(Vec::new);
-        counter!("engine_buffer_pool_borrows_total", 1, "buffer" => "action");
-        gauge!(
-            "engine_buffer_pool_available",
-            buffers.len() as f64,
-            "buffer" => "action"
-        );
+        counter!("engine_buffer_pool_borrows_total", "buffer" => "action").increment(1);
+        gauge!("engine_buffer_pool_available", "buffer" => "action").set(buffers.len() as f64);
         buffer
     }
 
@@ -178,17 +158,13 @@ impl BufferPool {
         // Shrink oversized buffers to prevent memory leaks from large allocations
         if buf.capacity() > MAX_BUFFER_CAPACITY {
             buf.shrink_to(MAX_BUFFER_CAPACITY);
-            counter!("engine_buffer_pool_shrinks_total", 1, "buffer" => "action");
+            counter!("engine_buffer_pool_shrinks_total", "buffer" => "action").increment(1);
         }
 
         let mut buffers = self.action_buffers.lock().unwrap();
         buffers.push(buf);
-        counter!("engine_buffer_pool_returns_total", 1, "buffer" => "action");
-        gauge!(
-            "engine_buffer_pool_available",
-            buffers.len() as f64,
-            "buffer" => "action"
-        );
+        counter!("engine_buffer_pool_returns_total", "buffer" => "action").increment(1);
+        gauge!("engine_buffer_pool_available", "buffer" => "action").set(buffers.len() as f64);
     }
 
     /// Get statistics about the buffer pool
@@ -268,21 +244,12 @@ impl PooledBuffer {
 
 impl BufferPool {
     fn record_buffer_levels(&self) {
-        gauge!(
-            "engine_buffer_pool_available",
-            self.state_buffers.lock().unwrap().len() as f64,
-            "buffer" => "state"
-        );
-        gauge!(
-            "engine_buffer_pool_available",
-            self.obs_buffers.lock().unwrap().len() as f64,
-            "buffer" => "obs"
-        );
-        gauge!(
-            "engine_buffer_pool_available",
-            self.action_buffers.lock().unwrap().len() as f64,
-            "buffer" => "action"
-        );
+        gauge!("engine_buffer_pool_available", "buffer" => "state")
+            .set(self.state_buffers.lock().unwrap().len() as f64);
+        gauge!("engine_buffer_pool_available", "buffer" => "obs")
+            .set(self.obs_buffers.lock().unwrap().len() as f64);
+        gauge!("engine_buffer_pool_available", "buffer" => "action")
+            .set(self.action_buffers.lock().unwrap().len() as f64);
     }
 }
 

--- a/services/engine-rust/engine-server/src/registry_init.rs
+++ b/services/engine-rust/engine-server/src/registry_init.rs
@@ -18,7 +18,7 @@ pub fn initialize_registry() {
     });
 
     let games = engine_core::registry::list_registered_games();
-    gauge!("engine_registry_games", games.len() as f64);
+    gauge!("engine_registry_games").set(games.len() as f64);
     info!(count = games.len(), "Initialized game registry");
 
     // Log registered games
@@ -30,7 +30,9 @@ pub fn initialize_registry() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use engine_core::registry::{clear_registry, create_game, is_registered, list_registered_games};
+    use engine_core::registry::{
+        clear_registry, create_game, is_registered, list_registered_games,
+    };
     use once_cell::sync::Lazy;
     use std::sync::Mutex;
 

--- a/services/engine-rust/engine-server/src/service.rs
+++ b/services/engine-rust/engine-server/src/service.rs
@@ -47,11 +47,8 @@ impl EngineService {
     }
 
     fn observe_rpc_latency(method: &'static str, start: Instant) {
-        histogram!(
-            "engine_rpc_latency_seconds",
-            start.elapsed().as_secs_f64(),
-            "method" => method
-        );
+        histogram!("engine_rpc_latency_seconds", "method" => method)
+            .record(start.elapsed().as_secs_f64());
     }
 
     /// Sample a random action from the action space
@@ -93,7 +90,8 @@ impl EngineService {
                 if total_size != low.len() {
                     return Err(format!(
                         "Continuous action space shape mismatch: shape product {} != low.len() {}",
-                        total_size, low.len()
+                        total_size,
+                        low.len()
                     ));
                 }
 
@@ -160,7 +158,7 @@ impl Engine for EngineService {
         &self,
         request: Request<EngineId>,
     ) -> TonicResult<Response<Capabilities>> {
-        counter!("engine_rpc_requests_total", 1, "method" => "get_capabilities");
+        counter!("engine_rpc_requests_total", "method" => "get_capabilities").increment(1);
         let start = Instant::now();
         let engine_id = request.into_inner();
 
@@ -168,10 +166,10 @@ impl Engine for EngineService {
         if !is_registered(&engine_id.env_id) {
             counter!(
                 "engine_rpc_failures_total",
-                1,
                 "method" => "get_capabilities",
                 "error" => "unknown_env"
-            );
+            )
+            .increment(1);
             Self::observe_rpc_latency("get_capabilities", start);
             return Err(Status::not_found(format!(
                 "Unknown env_id: {}",
@@ -185,10 +183,10 @@ impl Engine for EngineService {
             None => {
                 counter!(
                     "engine_rpc_failures_total",
-                    1,
                     "method" => "get_capabilities",
                     "error" => "create_failed"
-                );
+                )
+                .increment(1);
                 Self::observe_rpc_latency("get_capabilities", start);
                 return Err(Status::internal("Failed to create game instance"));
             }
@@ -199,9 +197,9 @@ impl Engine for EngineService {
 
         counter!(
             "engine_rpc_success_total",
-            1,
             "method" => "get_capabilities"
-        );
+        )
+        .increment(1);
 
         Self::observe_rpc_latency("get_capabilities", start);
 
@@ -209,7 +207,7 @@ impl Engine for EngineService {
     }
 
     async fn reset(&self, request: Request<ResetRequest>) -> TonicResult<Response<ResetResponse>> {
-        counter!("engine_rpc_requests_total", 1, "method" => "reset");
+        counter!("engine_rpc_requests_total", "method" => "reset").increment(1);
         let start = Instant::now();
         let req = request.into_inner();
 
@@ -218,10 +216,10 @@ impl Engine for EngineService {
             None => {
                 counter!(
                     "engine_rpc_failures_total",
-                    1,
                     "method" => "reset",
                     "error" => "missing_engine_id"
-                );
+                )
+                .increment(1);
                 Self::observe_rpc_latency("reset", start);
                 return Err(Status::invalid_argument("Missing engine_id"));
             }
@@ -239,18 +237,18 @@ impl Engine for EngineService {
         // Use DashMap's entry API for lock-free concurrent access
         let mut game_entry = match self.game_cache.entry(key) {
             Entry::Occupied(entry) => {
-                counter!("engine_game_cache_hits_total", 1, "method" => "reset");
+                counter!("engine_game_cache_hits_total", "method" => "reset").increment(1);
                 entry.into_ref()
             }
             Entry::Vacant(entry) => {
-                counter!("engine_game_cache_misses_total", 1, "method" => "reset");
+                counter!("engine_game_cache_misses_total", "method" => "reset").increment(1);
                 let Some(game) = create_game(env_id.as_ref()) else {
                     counter!(
                         "engine_rpc_failures_total",
-                        1,
                         "method" => "reset",
                         "error" => "unknown_env"
-                    );
+                    )
+                    .increment(1);
                     Self::observe_rpc_latency("reset", start);
                     return Err(Status::not_found(format!("Unknown env_id: {}", env_id)));
                 };
@@ -258,7 +256,7 @@ impl Engine for EngineService {
             }
         };
 
-        gauge!("engine_game_cache_entries", self.game_cache.len() as f64);
+        gauge!("engine_game_cache_entries").set(self.game_cache.len() as f64);
 
         // Perform reset
         if let Err(e) =
@@ -275,10 +273,10 @@ impl Engine for EngineService {
             );
             counter!(
                 "engine_rpc_failures_total",
-                1,
                 "method" => "reset",
                 "error" => "reset_failed"
-            );
+            )
+            .increment(1);
             Self::observe_rpc_latency("reset", start);
             return Err(Status::internal(format!(
                 "Reset failed: {} (env_id={}, seed={}, hint_size={})",
@@ -302,11 +300,7 @@ impl Engine for EngineService {
         self.buffer_pool.return_state_buffer(state_buf);
         self.buffer_pool.return_obs_buffer(obs_buf);
 
-        counter!(
-            "engine_rpc_success_total",
-            1,
-            "method" => "reset"
-        );
+        counter!("engine_rpc_success_total", "method" => "reset").increment(1);
 
         Self::observe_rpc_latency("reset", start);
 
@@ -314,7 +308,7 @@ impl Engine for EngineService {
     }
 
     async fn step(&self, request: Request<StepRequest>) -> TonicResult<Response<StepResponse>> {
-        counter!("engine_rpc_requests_total", 1, "method" => "step");
+        counter!("engine_rpc_requests_total", "method" => "step").increment(1);
         let start = Instant::now();
         let req = request.into_inner();
 
@@ -323,10 +317,10 @@ impl Engine for EngineService {
             None => {
                 counter!(
                     "engine_rpc_failures_total",
-                    1,
                     "method" => "step",
                     "error" => "missing_engine_id"
-                );
+                )
+                .increment(1);
                 Self::observe_rpc_latency("step", start);
                 return Err(Status::invalid_argument("Missing engine_id"));
             }
@@ -335,10 +329,10 @@ impl Engine for EngineService {
         if !is_registered(&engine_id.env_id) {
             counter!(
                 "engine_rpc_failures_total",
-                1,
                 "method" => "step",
                 "error" => "unknown_env"
-            );
+            )
+            .increment(1);
             Self::observe_rpc_latency("step", start);
             return Err(Status::not_found(format!(
                 "Unknown env_id: {}",
@@ -354,18 +348,18 @@ impl Engine for EngineService {
         // Use DashMap's get_mut for fine-grained locking
         let mut game_entry = match self.game_cache.get_mut(&key) {
             Some(entry) => {
-                counter!("engine_game_cache_hits_total", 1, "method" => "step");
-                gauge!("engine_game_cache_entries", self.game_cache.len() as f64);
+                counter!("engine_game_cache_hits_total", "method" => "step").increment(1);
+                gauge!("engine_game_cache_entries").set(self.game_cache.len() as f64);
                 entry
             }
             None => {
-                counter!("engine_game_cache_misses_total", 1, "method" => "step");
+                counter!("engine_game_cache_misses_total", "method" => "step").increment(1);
                 counter!(
                     "engine_rpc_failures_total",
-                    1,
                     "method" => "step",
                     "error" => "not_initialized"
-                );
+                )
+                .increment(1);
                 Self::observe_rpc_latency("step", start);
                 return Err(Status::failed_precondition(
                     "Game not initialized - call reset before step",
@@ -391,10 +385,10 @@ impl Engine for EngineService {
                     );
                     counter!(
                         "engine_rpc_failures_total",
-                        1,
                         "method" => "step",
                         "error" => "step_failed"
-                    );
+                    )
+                    .increment(1);
                     Self::observe_rpc_latency("step", start);
                     return Err(Status::internal(format!(
                         "Step failed: {} (env_id={}, state_size={}, action_size={})",
@@ -422,11 +416,7 @@ impl Engine for EngineService {
         self.buffer_pool.return_state_buffer(new_state_buf);
         self.buffer_pool.return_obs_buffer(obs_buf);
 
-        counter!(
-            "engine_rpc_success_total",
-            1,
-            "method" => "step"
-        );
+        counter!("engine_rpc_success_total", "method" => "step").increment(1);
 
         Self::observe_rpc_latency("step", start);
 
@@ -437,7 +427,7 @@ impl Engine for EngineService {
         &self,
         request: Request<BatchSimulateRequest>,
     ) -> TonicResult<Response<Self::BatchSimulateStream>> {
-        counter!("engine_rpc_requests_total", 1, "method" => "batch_simulate");
+        counter!("engine_rpc_requests_total", "method" => "batch_simulate").increment(1);
         let start = Instant::now();
         let req = request.into_inner();
 
@@ -447,10 +437,10 @@ impl Engine for EngineService {
             None => {
                 counter!(
                     "engine_rpc_failures_total",
-                    1,
                     "method" => "batch_simulate",
                     "error" => "missing_engine_id"
-                );
+                )
+                .increment(1);
                 Self::observe_rpc_latency("batch_simulate", start);
                 return Err(Status::invalid_argument("Missing engine_id"));
             }
@@ -460,10 +450,10 @@ impl Engine for EngineService {
         if !is_registered(&engine_id.env_id) {
             counter!(
                 "engine_rpc_failures_total",
-                1,
                 "method" => "batch_simulate",
                 "error" => "unknown_env"
-            );
+            )
+            .increment(1);
             Self::observe_rpc_latency("batch_simulate", start);
             return Err(Status::not_found(format!(
                 "Unknown env_id: {}",
@@ -475,10 +465,10 @@ impl Engine for EngineService {
         if req.trajectories.is_empty() {
             counter!(
                 "engine_rpc_failures_total",
-                1,
                 "method" => "batch_simulate",
                 "error" => "empty_batch"
-            );
+            )
+            .increment(1);
             Self::observe_rpc_latency("batch_simulate", start);
             return Err(Status::invalid_argument(
                 "No trajectories provided in batch",
@@ -491,10 +481,10 @@ impl Engine for EngineService {
             None => {
                 counter!(
                     "engine_rpc_failures_total",
-                    1,
                     "method" => "batch_simulate",
                     "error" => "create_failed"
-                );
+                )
+                .increment(1);
                 Self::observe_rpc_latency("batch_simulate", start);
                 return Err(Status::internal("Failed to create game instance"));
             }
@@ -508,15 +498,8 @@ impl Engine for EngineService {
         let return_states = req.return_states;
         let return_observations = req.return_observations;
 
-        counter!(
-            "engine_rpc_success_total",
-            1,
-            "method" => "batch_simulate"
-        );
-        counter!(
-            "engine_batch_simulate_trajectories_total",
-            trajectories.len() as u64,
-        );
+        counter!("engine_rpc_success_total", "method" => "batch_simulate").increment(1);
+        counter!("engine_batch_simulate_trajectories_total").increment(trajectories.len() as u64);
 
         Self::observe_rpc_latency("batch_simulate", start);
 
@@ -540,9 +523,9 @@ impl Engine for EngineService {
                         );
                         counter!(
                             "engine_batch_simulate_trajectory_failures_total",
-                            1,
                             "error" => "create_failed"
-                        );
+                        )
+                        .increment(1);
                         continue;
                     }
                 };
@@ -563,9 +546,9 @@ impl Engine for EngineService {
                     );
                     counter!(
                         "engine_batch_simulate_trajectory_failures_total",
-                        1,
                         "error" => "reset_failed"
-                    );
+                    )
+                    .increment(1);
                     buffer_pool.return_state_buffer(state_buf);
                     buffer_pool.return_obs_buffer(obs_buf);
                     buffer_pool.return_action_buffer(action_buf);
@@ -597,9 +580,9 @@ impl Engine for EngineService {
                         );
                         counter!(
                             "engine_batch_simulate_trajectory_failures_total",
-                            1,
                             "error" => "action_sample_failed"
-                        );
+                        )
+                        .increment(1);
                         break;
                     }
 
@@ -637,9 +620,9 @@ impl Engine for EngineService {
                             );
                             counter!(
                                 "engine_batch_simulate_trajectory_failures_total",
-                                1,
                                 "error" => "step_failed"
-                            );
+                            )
+                            .increment(1);
                             buffer_pool.return_state_buffer(next_state_buf);
                             buffer_pool.return_obs_buffer(next_obs_buf);
                             break;
@@ -682,18 +665,11 @@ impl Engine for EngineService {
                     total_reward,
                 });
 
-                counter!(
-                    "engine_batch_simulate_steps_total",
-                    total_steps as u64,
-                );
-                histogram!(
-                    "engine_batch_simulate_trajectory_steps",
-                    total_steps as f64,
-                );
-                histogram!(
-                    "engine_batch_simulate_trajectory_reward",
-                    total_reward as f64,
-                );
+                counter!("engine_batch_simulate_steps_total").increment(total_steps as u64);
+                histogram!("engine_batch_simulate_trajectory_steps")
+                    .record(total_steps as f64);
+                histogram!("engine_batch_simulate_trajectory_reward")
+                    .record(total_reward as f64);
             }
 
             // Send final chunk with all results
@@ -1343,7 +1319,9 @@ mod tests {
 
         let result = EngineService::sample_random_action(&action_space, &mut rng, &mut buf);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Discrete action space with n=0"));
+        assert!(result
+            .unwrap_err()
+            .contains("Discrete action space with n=0"));
     }
 
     #[test]
@@ -1377,7 +1355,9 @@ mod tests {
 
         let result = EngineService::sample_random_action(&action_space, &mut rng, &mut buf);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("MultiDiscrete action space with n=0"));
+        assert!(result
+            .unwrap_err()
+            .contains("MultiDiscrete action space with n=0"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- migrate engine server and buffer pool instrumentation to the new metrics macro API by chaining increment/set/record calls
- update actor telemetry to use the new counter, gauge, and histogram handles
- ensure registry metrics increment correctly under the revised macro semantics

## Testing
- cargo check (services/engine-rust)

------
https://chatgpt.com/codex/tasks/task_e_6903797c99d4833094936842d55dd618